### PR TITLE
Rewrite opening sensor states [BREAKING CHANGE]

### DIFF
--- a/package/bleparser/__init__.py
+++ b/package/bleparser/__init__.py
@@ -139,7 +139,7 @@ class BleParser:
             adpayload_start += adstuct_size
 
         # check for monitored device trackers
-        if mac.lower() in self.tracker_whitelist:
+        if mac in self.tracker_whitelist:
             tracker_data = {
                 "is connected": True,
                 "mac": ''.join('{:02X}'.format(x) for x in mac),

--- a/package/bleparser/atc.py
+++ b/package/bleparser/atc.py
@@ -100,7 +100,7 @@ def parse_atc(self, data, source_mac, rssi):
         return None
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and atc_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and atc_mac not in self.sensor_whitelist:
         return None
 
     try:

--- a/package/bleparser/brifit.py
+++ b/package/bleparser/brifit.py
@@ -43,7 +43,7 @@ def parse_brifit(self, data, source_mac, rssi):
         return None
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and brifit_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and brifit_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(brifit_mac))
         return None
 

--- a/package/bleparser/govee.py
+++ b/package/bleparser/govee.py
@@ -87,7 +87,7 @@ def parse_govee(self, data, source_mac, rssi):
         return None
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and govee_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and govee_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(govee_mac))
         return None
 

--- a/package/bleparser/inode.py
+++ b/package/bleparser/inode.py
@@ -87,7 +87,7 @@ def parse_inode(self, data, source_mac, rssi):
     self.lpacket_ids[inode_mac] = packet_id
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and inode_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and inode_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(inode_mac))
         return None
 

--- a/package/bleparser/kegtron.py
+++ b/package/bleparser/kegtron.py
@@ -74,7 +74,7 @@ def parse_kegtron(self, data, source_mac, rssi):
             return None
 
         # check for MAC presence in sensor whitelist, if needed
-        if self.discovery is False and kegtron_mac.lower() not in self.sensor_whitelist:
+        if self.discovery is False and kegtron_mac not in self.sensor_whitelist:
             _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(kegtron_mac))
             return None
 

--- a/package/bleparser/miscale.py
+++ b/package/bleparser/miscale.py
@@ -99,7 +99,7 @@ def parse_miscale(self, data, source_mac, rssi):
             return None
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and miscale_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and miscale_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(miscale_mac))
         return None
 

--- a/package/bleparser/qingping.py
+++ b/package/bleparser/qingping.py
@@ -64,7 +64,7 @@ def parse_qingping(self, data, source_mac, rssi):
         return None
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and qingping_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and qingping_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(qingping_mac))
         return None
 

--- a/package/bleparser/ruuvitag.py
+++ b/package/bleparser/ruuvitag.py
@@ -192,7 +192,7 @@ def parse_ruuvitag(self, data, source_mac, rssi):
             batt = 0
         result["battery"] = round(batt, 1)
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and ruuvitag_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and ruuvitag_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(ruuvitag_mac))
         return None
     if version < 5:

--- a/package/bleparser/sensorpush.py
+++ b/package/bleparser/sensorpush.py
@@ -97,7 +97,7 @@ def parse_sensorpush(self, data, source_mac, rssi):
         return None
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and sensorpush_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and sensorpush_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(sensorpush_mac))
         return None
 

--- a/package/bleparser/teltonika.py
+++ b/package/bleparser/teltonika.py
@@ -54,7 +54,7 @@ def parse_teltonika(self, data, source_mac, rssi):
         return None
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and teltonika_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and teltonika_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(teltonika_mac))
         return None
 

--- a/package/bleparser/thermoplus.py
+++ b/package/bleparser/thermoplus.py
@@ -58,7 +58,7 @@ def parse_thermoplus(self, data, source_mac, rssi):
         return None
 
     # check for MAC presence in sensor whitelist, if needed
-    if self.discovery is False and thermoplus_mac.lower() not in self.sensor_whitelist:
+    if self.discovery is False and thermoplus_mac not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(thermoplus_mac))
         return None
 

--- a/package/bleparser/xiaomi.py
+++ b/package/bleparser/xiaomi.py
@@ -318,7 +318,23 @@ def obj1018(xobj):
 
 
 def obj1019(xobj):
-    return {"opening": xobj[0]}
+    open = xobj[0]
+    if open == 0:
+        opening = 1
+        status = "opened"
+    elif open == 1:
+        opening = 0
+        status = "closed"
+    elif open == 2:
+        opening = 1
+        status = "closing timeout"
+    elif open == 3:
+        opening = 1
+        status = "device reset"
+    else:
+        opening = 0
+        status = None
+    return {"opening": opening, "status": status}
 
 
 def obj100a(xobj):


### PR DESCRIPTION
- The opening sensor state has been reversed, to meet with Home Assistant/BLE monitor definitions for open and closed. Added an extra status output with description of the status. 
- removed the lower() from mac.lower() in the parsers and device tracker
