### PR TITLE
Device specific output for Xiaomi button/remote/switch/dimmer and light/motion/illuminance advertisements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bleparser
-version = 0.9.1
+version = 1.0.0
 author = Ernst79
 author_email = e.klamer@gmail.com
 description = Parser for passive BLE advertisements


### PR DESCRIPTION
The `button/remote/switch/dimmer` advertisements and `light/motion/illuminance` advertisements of Xiaomi sensors are now only returning the output that correspond to the device that has sent the advertisements. 

In the previous versions, bleparser was giving all possible outputs for all device types that use the same data object (`0x000F` and `0x1001`) and the user had to filter which result was relevant for his sensor. It now only returns the device specific results (e.g. a `dimmer` won't return a `bathroom remote command` anymore). 

Fix #1