### PR TITLE
Oral-B, b-parasite and Inkbird iBBQ sensors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ernst Klamer
+Copyright (c) 2022 Ernst Klamer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ pip install bleparser
 Supported sensor brands
 
 - ATC (custom firmware for Xiaomi/Qingping sensors)
+- B-parasite
 - BlueMaestro
 - Brifit
 - Govee
-- iNode sensors
+- Inkbird iBBQ
+- iNode
 - Kegtron
 - Moat
+- Oral-B
 - Qingping
 - Ruuvitag
 - SensorPush
@@ -53,7 +56,7 @@ ble_parser = BleParser(
 ```
 
 **report_unknown**
-Report unknown sensors. Can be set to `ATC`, `BlueMaestro`, `Brifit`, `Govee`, `iNode`, `Kegtron`, `Moat`, `Mi Scale`, `Qingping`, `Ruuvitag`, `SensorPush`, `Teltonika`, `Thermoplus`, `Xiaogui` or `Xiaomi` to report unknown sensors of a specific brand to the logger. You can set it to `Other` to report all unknown advertisements to the logger. Default: `False`
+Report unknown sensors. Can be set to `ATC`, `b-parasite`, `BlueMaestro`, `Brifit`, `Govee`, `Inkbird`, `iNode`, `Kegtron`, `Moat`, `Mi Scale`, `Oral-B`, `Qingping`, `Ruuvitag`, `SensorPush`, `Teltonika`, `Thermoplus`, `Xiaogui` or `Xiaomi` to report unknown sensors of a specific brand to the logger. You can set it to `Other` to report all unknown advertisements to the logger. Default: `False`
 
 **discovery**
 Boolean. When set to `False`, only sensors in sensor_whitelist will be parsed. Default: `True`

--- a/package/bleparser/bparasite.py
+++ b/package/bleparser/bparasite.py
@@ -1,0 +1,72 @@
+"""Parser for BParasite BLE advertisements"""
+import logging
+from struct import unpack
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_bparasite(self, data, source_mac, rssi):
+    """Check for adstruc length"""
+    msg_length = len(data)
+    if msg_length == 22: # TODO: Use version bits?
+        bpara_mac = data[14:20]
+        device_type = "b-parasite V1.1.0"
+        firmware = "b-parasite V1.1.0 (with illuminance)"
+        (protocol, packet_id, batt, temp, humi, moist, mac, light) = unpack(">BBHHHH6sH", data[4:])
+        result = {
+            "temperature": temp / 1000,
+            "humidity": (humi / 65536) * 100,
+            "voltage": batt / 1000.0,
+            "moisture": (moist / 65536) * 100,
+            "illuminance": light,
+            "data": True
+        }
+    elif msg_length == 20:
+        bpara_mac = data[14:20]
+        device_type = "b-parasite V1.0.0"
+        firmware = "b-parasite V1.0.0 (without illuminance)"
+        (protocol, packet_id, batt, temp, humi, moist, mac) = unpack(">BBHHHH6s", data[4:])
+        result = {
+            "temperature": temp / 1000,
+            "humidity": (humi / 65536) * 100,
+            "voltage": batt / 1000.0,
+            "moisture": (moist / 65536) * 100,
+            "data": True
+        }
+    else:
+        if self.report_unknown == "b-parasite":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN b-parasite DEVICE: RSSI: %s, MAC: %s, AdStruct(%d): %s",
+                rssi,
+                (source_mac),
+                msg_length,
+                data.hex()
+            )
+        return None
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and bpara_mac not in self.sensor_whitelist:
+        return None
+
+    try:
+        prev_packet = self.lpacket_ids[bpara_mac]
+    except KeyError:
+        # start with empty first packet
+        prev_packet = None
+    
+    if self.filter_duplicates is True:
+        # only process messages with same priority that have a changed packet id
+        if prev_packet == packet_id:
+            return None
+
+    self.lpacket_ids[bpara_mac] = packet_id
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join('{:02X}'.format(x) for x in bpara_mac),
+        "type": device_type,
+        "packet": packet_id,
+        "firmware": firmware,
+    })
+
+    return result

--- a/package/bleparser/inkbird.py
+++ b/package/bleparser/inkbird.py
@@ -1,0 +1,64 @@
+"""Parser for Inkbird BLE advertisements"""
+import logging
+from struct import unpack
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_inkbird(self, data, source_mac, rssi):
+    """parser for inkbird iBBQ thermometer"""
+    msg_length = len(data)
+    firmware = "Inkbird"
+    result = {"firmware": firmware}
+    inkbird_mac = data[6:12]
+    if inkbird_mac != source_mac:
+        _LOGGER.debug("Inkbird MAC address doesn't match data MAC address. Data: %s", data.hex())
+        return None
+
+    xvalue = data[12:16]
+    if msg_length == 16:
+        device_type = "iBBQ-2"
+        (temp_1, temp_2) = unpack("<HH", xvalue)
+        if temp_1 < 60000:
+            temperature_1 = temp_1 / 10.0
+        else:
+            temperature_1 = 0
+        if temp_2 < 60000:
+            temperature_2 = temp_2 / 10.0
+        else:
+            temperature_2 = 0
+        result.update(
+            {
+                "temperature probe 1": temperature_1,
+                "temperature probe 2": temperature_2,
+            }
+        )
+    else:
+        if self.report_unknown == "Inkbird":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Inkbird DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and inkbird_mac.lower() not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(inkbird_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join('{:02X}'.format(x) for x in inkbird_mac[:]),
+        "type": device_type,
+        "packet": "no packet id",
+        "firmware": firmware,
+        "data": True
+    })
+    return result
+
+
+def to_mac(addr: int):
+    """Convert MAC address."""
+    return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/bleparser/oral_b.py
+++ b/package/bleparser/oral_b.py
@@ -1,0 +1,109 @@
+"""Parser for Moat BLE advertisements."""
+import logging
+from struct import unpack
+
+_LOGGER = logging.getLogger(__name__)
+
+STATES = {
+    0: "unknown",
+    1: "initializing",
+    2: "idle",
+    3: "running",
+    4: "charging",
+    5: "setup",
+    6: "flight menu",
+    113: "final test",
+    114: "pcb test",
+    115: "sleeping",
+    116: "transport"
+}
+
+MODES = {
+    0: "off",
+    1: "daily clean",
+    2: "sensitive",
+    3: "massage",
+    4: "whitening",
+    5: "deep clean",
+    6: "tongue cleaning",
+    7: "turbo",
+    255: "unknown"
+}
+
+SECTORS = {
+    1: "sector 1",
+    2: "sector 2",
+    3: "sector 3",
+    4: "sector 4",
+    5: "sector 5",
+    6: "sector 6",
+    7: "sector 7",
+    8: "sector 8",
+    15: "unknown 1",
+    31: "unknown 2",
+    23: "unknown 3",
+    47: "unknown 4",
+    55: "unknown 5",
+    254: "last sector",
+    255: "no sector"
+}
+
+
+def parse_oral_b(self, data, source_mac, rssi):
+    """Parser for Oral-B toothbrush."""
+    msg_length = len(data)
+    print(data.hex())
+    firmware = "Oral-B"
+    oral_b_mac = source_mac
+    result = {"firmware": firmware}
+    if msg_length == 15:
+        print(data[7:15].hex())
+        device_type = "SmartSeries 7000"
+        (state, pressure, counter, mode, sector, sector_timer, no_of_sectors) = unpack(
+            ">BBHBBBB", data[7:15]
+        )
+
+        if state == 3:
+            result.update({"toothbrush": 1})
+        else:
+            result.update({"toothbrush": 0})
+
+        result.update({
+            "toothbrush state": STATES[state],
+            "pressure": pressure,
+            "counter": counter,
+            "mode": MODES[mode],
+            "sector": SECTORS[sector],
+            "sector timer": sector_timer,
+            "number of sectors": no_of_sectors,
+        })
+
+    else:
+        if self.report_unknown == "Oral-B":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Moat DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+
+    # check for MAC presence in whitelist, if needed
+    if self.discovery is False and oral_b_mac.lower() not in self.whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(oral_b_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join('{:02X}'.format(x) for x in oral_b_mac[:]),
+        "type": device_type,
+        "packet": "no packet id",
+        "firmware": firmware,
+        "data": True
+    })
+    return result
+
+
+def to_mac(addr: int):
+    """Return formatted MAC address"""
+    return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/tests/test_bparasite.py
+++ b/package/tests/test_bparasite.py
@@ -1,0 +1,45 @@
+"""The tests for the b-parasite ble_parser."""
+from bleparser import BleParser
+
+
+class TestBParasite:
+    """Tests for the bparasite parser"""
+
+    def test_bparasite_v2(self):
+        """Test bparasite parser for v2 format (with illuminance)"""
+        data_string = "043e2b020103010102caf0caf01f02010415161a18110b0aa1542cbca1fffff0caf0ca0201004205096e524635b8"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "b-parasite V1.1.0 (with illuminance)"
+        assert sensor_msg["type"] == "b-parasite V1.1.0"
+        assert sensor_msg["mac"] == "F0CAF0CA0201"
+        assert sensor_msg["packet"] == 11
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 21.548 
+        assert sensor_msg["humidity"] == 73.68316650390625 
+        assert sensor_msg["voltage"] == 2.721
+        assert sensor_msg["illuminance"] == 66
+        assert sensor_msg["moisture"] == 99.99847412109375
+        assert sensor_msg["rssi"] == -72
+
+    def test_bparasite_v1(self):
+        """Test bparasite parser for v1 format (without illuminance)"""
+        data_string = "043e29020103010102caf0caf01d02010413161a18100b0aa1542cbca1fffff0caf0ca020105096e524635b8"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "b-parasite V1.0.0 (without illuminance)"
+        assert sensor_msg["type"] == "b-parasite V1.0.0"
+        assert sensor_msg["mac"] == "F0CAF0CA0201"
+        assert sensor_msg["packet"] == 11
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 21.548 
+        assert sensor_msg["humidity"] == 73.68316650390625 
+        assert sensor_msg["voltage"] == 2.721
+        assert sensor_msg["moisture"] == 99.99847412109375
+        assert sensor_msg["rssi"] == -72

--- a/package/tests/test_inkbird.py
+++ b/package/tests/test_inkbird.py
@@ -1,0 +1,23 @@
+"""The tests for the Inkbird ble_parser."""
+from bleparser import BleParser
+
+
+class TestInkbird:
+    """Tests for the Inkbird parser"""
+    def test_inkbird_iBBQ_2_probes(self):
+        """Test Inkbird parser for Inkbird iBBQ with 2 probes."""
+        data_string = "043e23020100007bf4abb51434170201060302f0ff0fff000000003414b5abf47bc800d200e5"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Inkbird"
+        assert sensor_msg["type"] == "iBBQ-2"
+        assert sensor_msg["mac"] == "3414B5ABF47B"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature probe 1"] == 20.0
+        assert sensor_msg["temperature probe 2"] == 21.0
+        assert sensor_msg["rssi"] == -27

--- a/package/tests/test_oral_b.py
+++ b/package/tests/test_oral_b.py
@@ -1,0 +1,29 @@
+"""The tests for the Oral-B ble_parser."""
+from bleparser import BleParser
+
+
+class TestOralB:
+    """Tests for the Oral-B parser"""
+    def test_oral_b_smartseries_7000(self):
+        """Test Oral-B parser for Oral-B SmartSeries 7000."""
+        data_string = "043e1e020100007173b66a1ba8120201050effdc0003210b0328041107373804b7"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        print(sensor_msg)
+        assert sensor_msg["firmware"] == "Oral-B"
+        assert sensor_msg["type"] == "SmartSeries 7000"
+        assert sensor_msg["mac"] == "A81B6AB67371"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["toothbrush"] == 1
+        assert sensor_msg["toothbrush state"] == 'running'
+        assert sensor_msg["pressure"] == 40
+        assert sensor_msg["counter"] == 1041
+        assert sensor_msg["mode"] == 'turbo'
+        assert sensor_msg["sector"] == 'unknown 5'
+        assert sensor_msg["sector timer"] == 56
+        assert sensor_msg["number of sectors"] == 4
+        assert sensor_msg["rssi"] == -73

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,1 +1,1 @@
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bleparser
-version = 1.5.0
+version = 1.6.0
 author = Ernst79
 author_email = e.klamer@gmail.com
 description = Parser for passive BLE advertisements


### PR DESCRIPTION
This PR adds support for:

- Oral-B toothbrush (7000 series)
- b-parasite plant sensors
- Inkbird iBBQ sensors (currently only 2 probes version). 