### PR TITLE
Inkbird and Govee sensors

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/package/bleparser/__init__.py
+++ b/package/bleparser/__init__.py
@@ -141,7 +141,7 @@ class BleParser:
                 if man_spec_data[0] == 0x1E and comp_id == 0xFFFF:  # Kegtron
                     sensor_data = parse_kegtron(self, man_spec_data, mac, rssi)
                     break
-                elif man_spec_data[0] == 0x15 and (comp_id == 0x0010 or comp_id == 0x0011):  # Thermoplus
+                elif man_spec_data[0] == 0x15 and comp_id in [0x0010, 0x0011]:  # Thermoplus
                     sensor_data = parse_thermoplus(self, man_spec_data, mac, rssi)
                     break
                 elif man_spec_data[0] == 0x0C and comp_id == 0xEC88:  # Govee H5051
@@ -171,10 +171,7 @@ class BleParser:
                 elif man_spec_data[0] == 0x14 and (comp_id == 0xaa55):  # Brifit
                     sensor_data = parse_brifit(self, man_spec_data, mac, rssi)
                     break
-                elif man_spec_data[0] == 0x0F and service_class_uuid16 == 0xF0FF:  # Inkbird iBBQ-2
-                    sensor_data = parse_inkbird(self, man_spec_data, mac, rssi)
-                    break
-                elif man_spec_data[0] == 0x13 and complete_local_name == "iBBQ":  # Inkbird iBBQ-4
+                elif man_spec_data[0] in [0x0F, 0x13] and service_class_uuid16 == 0xF0FF:  # Inkbird iBBQ
                     sensor_data = parse_inkbird(self, man_spec_data, mac, rssi)
                     break
                 elif man_spec_data[0] == 0x0A and complete_local_name == "sps":  # Inkbird IBS-TH2
@@ -201,7 +198,7 @@ class BleParser:
                 elif man_spec_data[0] == 0x0E and comp_id == 0x00DC:  # Oral-b
                     sensor_data = parse_oral_b(self, man_spec_data, mac, rssi)
                     break
-                elif man_spec_data[0] == 0x06 or man_spec_data[0] == 0x08 and service_class_uuid128 == b'\xb0\x0a\x09\xec\xd7\x9d\xb8\x93\xba\x42\xd6\x11\x00\x00\x09\xef':  # Sensorpush
+                elif man_spec_data[0] in [0x06, 0x08] and service_class_uuid128 == b'\xb0\x0a\x09\xec\xd7\x9d\xb8\x93\xba\x42\xd6\x11\x00\x00\x09\xef':  # Sensorpush
                     sensor_data = parse_sensorpush(self, man_spec_data, mac, rssi)
                     break
                 else:

--- a/package/bleparser/__init__.py
+++ b/package/bleparser/__init__.py
@@ -73,114 +73,144 @@ class BleParser:
         # MAC address
         mac = (data[8 if is_ext_packet else 7:14 if is_ext_packet else 13])[::-1]
         sensor_data = None
+        complete_local_name = ""
+        service_class_uuid16 = None
+        service_class_uuid128 = None
+        service_data = b''
+        man_spec_data = b''
+
         while adpayload_size > 1:
             adstuct_size = data[adpayload_start] + 1
             if adstuct_size > 1 and adstuct_size <= adpayload_size:
                 adstruct = data[adpayload_start:adpayload_start + adstuct_size]
                 # https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile/
                 adstuct_type = adstruct[1]
-                if adstuct_type == 0x16 and adstuct_size > 4:
-                    # AD type 'UUI16' https://www.bluetooth.com/specifications/assigned-numbers/
+                if adstuct_type == 0x02:
+                    # AD type 'Incomplete List of 16-bit Service Class UUIDs'
+                    service_class_uuid16 = (adstruct[2] << 8) | adstruct[3]
+                elif adstuct_type == 0x03:
+                    # AD type 'Complete List of 16-bit Service Class UUIDs'
+                    service_class_uuid16 = (adstruct[2] << 8) | adstruct[3]
+                elif adstuct_type == 0x06:
+                    # AD type '128-bit Service Class UUIDs'
+                    service_class_uuid128 = adstruct[2:]
+                elif adstuct_type == 0x09:
+                    # AD type 'complete local name'
+                    complete_local_name = adstruct[2:].decode("utf-8")
+                elif adstuct_type == 0x16 and adstuct_size > 4:
+                    # AD type 'Service Data - 16-bit UUID'
                     uuid16 = (adstruct[3] << 8) | adstruct[2]
-                    # check for service data of supported manufacturers
-                    if uuid16 == 0xFFF9 or uuid16 == 0xFDCD:  # UUID16 = Cleargrass or Qingping
-                        sensor_data = parse_qingping(self, adstruct, mac, rssi)
-                        break
-                    elif uuid16 == 0x181A:  # UUID16 = ATC or b-parasite
-                        if len(adstruct) == 22 or len(adstruct) == 20:
-                            sensor_data = parse_bparasite(self, adstruct, mac, rssi)
-                        else:
-                            sensor_data = parse_atc(self, adstruct, mac, rssi)
-                        break
-                    elif uuid16 == 0xFE95:  # UUID16 = Xiaomi
-                        sensor_data = parse_xiaomi(self, adstruct, mac, rssi)
-                        break
-                    elif uuid16 == 0x181D or uuid16 == 0x181B:  # UUID16 = Mi Scale
-                        sensor_data = parse_miscale(self, adstruct, mac, rssi)
-                        break
-                    elif uuid16 == 0xFEAA:  # UUID16 = Ruuvitag V2/V4
-                        sensor_data = parse_ruuvitag(self, adstruct, mac, rssi)
-                        break
-                    elif uuid16 == 0x2A6E or uuid16 == 0x2A6F:  # UUID16 = Teltonika
-                        # Teltonika can contain multiple sevice data payloads in one advertisement
-                        sensor_data = parse_teltonika(self, data[adpayload_start:], mac, rssi)
-                        break
-                    else:
-                        if self.report_unknown == "Other":
-                            _LOGGER.info("Unknown advertisement received: %s", data.hex())
+                    service_data += adstruct
                 elif adstuct_type == 0xFF:
-                    # AD type 'Manufacturer Specific Data' with company identifier
+                    # AD type 'Manufacturer Specific Data'
+                    man_spec_data = adstruct
                     # https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
-                    comp_id = (adstruct[3] << 8) | adstruct[2]
-                    # check for service data of supported companies
-                    if adstruct[0] == 0x1E and comp_id == 0xFFFF:  # Kegtron
-                        sensor_data = parse_kegtron(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x15 and (comp_id == 0x0010 or comp_id == 0x0011):  # Thermoplus
-                        sensor_data = parse_thermoplus(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x0C and comp_id == 0xEC88:  # Govee H5051
-                        sensor_data = parse_govee(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x0A and comp_id == 0xEC88:  # Govee H5074
-                        sensor_data = parse_govee(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x09 and comp_id == 0xEC88:  # Govee H5072/H5075
-                        sensor_data = parse_govee(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x09 and comp_id == 0x0001:  # Govee H5101/H5102/H5177
-                        sensor_data = parse_govee(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x0C and comp_id == 0x0001:  # Govee H5178
-                        sensor_data = parse_govee(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x0C and comp_id == 0x8801:  # Govee H5179
-                        sensor_data = parse_govee(self, adstruct, mac, rssi)
-                        break
-                    elif comp_id == 0x0499:  # Ruuvitag V3/V5
-                        sensor_data = parse_ruuvitag(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x14 and (comp_id == 0xaa55):  # Brifit
-                        sensor_data = parse_brifit(self, adstruct, mac, rssi)
-                        break
-                    if adstruct[0] == 0x0F and comp_id == 0x0000:  # Inkbird
-                        sensor_data = parse_inkbird(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x0E and adstruct[3] == 0x82:  # iNode
-                        sensor_data = parse_inode(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x19 and adstruct[3] in [0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x9A, 0x9B, 0x9C, 0x9D]:  # iNode Care Sensors
-                        sensor_data = parse_inode(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x15 and comp_id == 0x1000:  # Moat S2
-                        sensor_data = parse_moat(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x11 and comp_id == 0x0133:  # BlueMaestro
-                        sensor_data = parse_bluemaestro(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x10 and adstruct[2] == 0xC0:  # Xiaogui Scale
-                        sensor_data = parse_xiaogui(self, adstruct, mac, rssi)
-                        break
-                    elif adstruct[0] == 0x0E and comp_id == 0x00DC:  # Oral-b
-                        sensor_data = parse_oral_b(self, adstruct, mac, rssi)
-                        break
-                    else:
-                        if self.report_unknown == "Other":
-                            _LOGGER.info("Unknown advertisement received: %s", data.hex())
-                elif adstuct_type == 0x06 and adstuct_size > 16:
-                    sensorpush_uuid_reversed = b'\xb0\x0a\x09\xec\xd7\x9d\xb8\x93\xba\x42\xd6\x11\x00\x00\x09\xef'
-                    if str(adstruct[2:]) == str(sensorpush_uuid_reversed):
-                        sensor_data = parse_sensorpush(self, data[adpayload_start:], mac, rssi)
-                        break
-                    else:
-                        if self.report_unknown == "Other":
-                            _LOGGER.info("Unknown advertisement received: %s", data.hex())
-                else:
-                    if self.report_unknown == "Other":
-                        _LOGGER.info("Unknown advertisement received: %s", data.hex())
-                    sensor_data = None
             adpayload_size -= adstuct_size
             adpayload_start += adstuct_size
+
+        while not sensor_data:
+            if service_data:
+                # parse data for sensors with service data
+                if uuid16 == 0xFFF9 or uuid16 == 0xFDCD:  # UUID16 = Cleargrass or Qingping
+                    sensor_data = parse_qingping(self, service_data, mac, rssi)
+                    break
+                elif uuid16 == 0x181A:  # UUID16 = ATC or b-parasite
+                    if len(service_data) == 22 or len(service_data) == 20:
+                        sensor_data = parse_bparasite(self, service_data, mac, rssi)
+                    else:
+                        sensor_data = parse_atc(self, service_data, mac, rssi)
+                    break
+                elif uuid16 == 0xFE95:  # UUID16 = Xiaomi
+                    sensor_data = parse_xiaomi(self, service_data, mac, rssi)
+                    break
+                elif uuid16 == 0x181D or uuid16 == 0x181B:  # UUID16 = Mi Scale
+                    sensor_data = parse_miscale(self, service_data, mac, rssi)
+                    break
+                elif uuid16 == 0xFEAA:  # UUID16 = Ruuvitag V2/V4
+                    sensor_data = parse_ruuvitag(self, service_data, mac, rssi)
+                    break
+                elif uuid16 == 0x2A6E or uuid16 == 0x2A6F:  # UUID16 = Teltonika
+                    # Teltonika can contain multiple sevice data payloads in one advertisement
+                    sensor_data = parse_teltonika(self, service_data, complete_local_name, mac, rssi)
+                    break
+                else:
+                    unknown_sensor = True
+            elif man_spec_data:
+                # parse data for sensors with manufacturer specific data
+                comp_id = (man_spec_data[3] << 8) | man_spec_data[2]
+                if man_spec_data[0] == 0x1E and comp_id == 0xFFFF:  # Kegtron
+                    sensor_data = parse_kegtron(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x15 and (comp_id == 0x0010 or comp_id == 0x0011):  # Thermoplus
+                    sensor_data = parse_thermoplus(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x0C and comp_id == 0xEC88:  # Govee H5051
+                    sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x0A and comp_id == 0xEC88:  # Govee H5051/H5074
+                    sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x09 and comp_id == 0xEC88:  # Govee H5072/H5075
+                    sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x09 and comp_id == 0x0001:  # Govee H5101/H5102/H5177
+                    sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x0C and comp_id == 0x0001:  # Govee H5178
+                    sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x0C and comp_id == 0x8801:  # Govee H5179
+                    sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x11 and service_class_uuid16 == 0x5183:  # Govee H5183
+                    sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                    break
+                elif comp_id == 0x0499:  # Ruuvitag V3/V5
+                    sensor_data = parse_ruuvitag(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x14 and (comp_id == 0xaa55):  # Brifit
+                    sensor_data = parse_brifit(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x0F and service_class_uuid16 == 0xF0FF:  # Inkbird iBBQ-2
+                    sensor_data = parse_inkbird(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x13 and complete_local_name == "iBBQ":  # Inkbird iBBQ-4
+                    sensor_data = parse_inkbird(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x0A and complete_local_name == "sps":  # Inkbird IBS-TH2
+                    sensor_data = parse_inkbird(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x0E and man_spec_data[3] == 0x82:  # iNode
+                    sensor_data = parse_inode(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x19 and man_spec_data[3] in [0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x9A, 0x9B, 0x9C, 0x9D]:  # iNode Care Sensors
+                    sensor_data = parse_inode(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x15 and comp_id == 0x1000:  # Moat S2
+                    sensor_data = parse_moat(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x11 and comp_id == 0x0133:  # BlueMaestro
+                    sensor_data = parse_bluemaestro(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x11 and comp_id == 0x0133:  # BlueMaestro
+                    sensor_data = parse_bluemaestro(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x10 and adstruct[2] == 0xC0:  # Xiaogui Scale
+                    sensor_data = parse_xiaogui(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x0E and comp_id == 0x00DC:  # Oral-b
+                    sensor_data = parse_oral_b(self, man_spec_data, mac, rssi)
+                    break
+                elif man_spec_data[0] == 0x06 or man_spec_data[0] == 0x08 and service_class_uuid128 == b'\xb0\x0a\x09\xec\xd7\x9d\xb8\x93\xba\x42\xd6\x11\x00\x00\x09\xef':  # Sensorpush
+                    sensor_data = parse_sensorpush(self, man_spec_data, mac, rssi)
+                    break
+                else:
+                    unknown_sensor = True
+            else:
+                unknown_sensor = True
+            if unknown_sensor and self.report_unknown == "Other":
+                _LOGGER.info("Unknown advertisement received: %s", data.hex())
+            break
 
         # check for monitored device trackers
         if mac in self.tracker_whitelist:

--- a/package/bleparser/atc.py
+++ b/package/bleparser/atc.py
@@ -1,13 +1,13 @@
-# Parser for ATC BLE advertisements
-from Cryptodome.Cipher import AES
+"""Parser for ATC BLE advertisements"""
 import logging
 from struct import unpack
+from Cryptodome.Cipher import AES
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def parse_atc(self, data, source_mac, rssi):
-    # check for adstruc length
+    """Check for adstruc length"""
     device_type = "ATC"
     msg_length = len(data)
     if msg_length == 19:
@@ -22,7 +22,8 @@ def parse_atc(self, data, source_mac, rssi):
             "voltage": volt / 1000,
             "battery": batt,
             "switch": (trg >> 1) & 1,
-            "opening": (trg ^ 1) & 1,
+            "opening": (~trg ^ 1) & 1,
+            "status": "opened",
             "data": True
         }
         adv_priority = 39
@@ -59,7 +60,8 @@ def parse_atc(self, data, source_mac, rssi):
                 "voltage": volt,
                 "battery": batt,
                 "switch": (trg >> 1) & 1,
-                "opening": (trg ^ 1) & 1,
+                "opening": (~trg ^ 1) & 1,
+                "status": "opened",
                 "data": True
             }
             adv_priority = 39
@@ -140,7 +142,7 @@ def parse_atc(self, data, source_mac, rssi):
 
 
 def decrypt_atc(self, data, atc_mac):
-    # try to find encryption key for current device
+    """Try to find encryption key for current device"""
     try:
         key = self.aeskeys[atc_mac]
         if len(key) != 16:
@@ -176,4 +178,5 @@ def decrypt_atc(self, data, atc_mac):
 
 
 def to_mac(addr: int):
+    """Convert MAC address."""
     return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/bleparser/govee.py
+++ b/package/bleparser/govee.py
@@ -76,6 +76,12 @@ def parse_govee(self, data, source_mac, rssi):
         device_type = "H5179"
         (temp, humi, batt) = unpack("<hHB", data[8:13])
         result.update({"temperature": temp / 100, "humidity": humi / 100, "battery": batt})
+    elif msg_length == 18:
+        device_type = "H5183"
+        (temp_probe, temp_alarm) = unpack(">hh", data[12:16])
+        temp_probe = 0 if temp_probe < 0 else temp_probe
+        temp_alarm = 0 if temp_alarm < 0 else temp_alarm
+        result.update({"temperature probe 1": temp_probe / 100, "temperature alarm": temp_alarm / 100})
     else:
         if self.report_unknown == "Govee":
             _LOGGER.info(

--- a/package/bleparser/inkbird.py
+++ b/package/bleparser/inkbird.py
@@ -5,32 +5,67 @@ from struct import unpack
 _LOGGER = logging.getLogger(__name__)
 
 
+def convert_temperature(temp):
+    """Temperature converter"""
+    if temp > 0:
+        temperature = temp / 10.0
+    else:
+        temperature = 0
+    return temperature
+
+
 def parse_inkbird(self, data, source_mac, rssi):
-    """parser for inkbird iBBQ thermometer"""
+    """Inkbird parser"""
     msg_length = len(data)
     firmware = "Inkbird"
     result = {"firmware": firmware}
-    inkbird_mac = data[6:12]
-    if inkbird_mac != source_mac:
-        _LOGGER.debug("Inkbird MAC address doesn't match data MAC address. Data: %s", data.hex())
-        return None
-
-    xvalue = data[12:16]
-    if msg_length == 16:
-        device_type = "iBBQ-2"
-        (temp_1, temp_2) = unpack("<HH", xvalue)
-        if temp_1 < 60000:
-            temperature_1 = temp_1 / 10.0
-        else:
-            temperature_1 = 0
-        if temp_2 < 60000:
-            temperature_2 = temp_2 / 10.0
-        else:
-            temperature_2 = 0
+    if msg_length == 11:
+        device_type = "IBS-TH2"
+        inkbird_mac = source_mac
+        xvalue = data[2:10]
+        (temp, hum) = unpack("<hH", xvalue[0:4])
+        bat = int.from_bytes(xvalue[7:8], 'little')
         result.update(
             {
-                "temperature probe 1": temperature_1,
-                "temperature probe 2": temperature_2,
+                "temperature": temp / 100,
+                "humidity": hum / 100,
+                "battery": bat,
+            }
+        )
+    elif msg_length == 16:
+        device_type = "iBBQ-2"
+        inkbird_mac = data[6:12]
+        xvalue = data[12:16]
+        if inkbird_mac != source_mac:
+            _LOGGER.debug(
+                "Inkbird MAC address doesn't match data MAC address. Data: %s",
+                data.hex()
+            )
+            return None
+        (temp_1, temp_2) = unpack("<HH", xvalue)
+        result.update(
+            {
+                "temperature probe 1": convert_temperature(temp_1),
+                "temperature probe 2": convert_temperature(temp_2),
+            }
+        )
+    elif msg_length == 20:
+        inkbird_mac = data[6:12]
+        xvalue = data[12:20]
+        if inkbird_mac != source_mac:
+            _LOGGER.debug(
+                "Inkbird MAC address doesn't match data MAC address. Data: %s",
+                data.hex()
+            )
+            return None
+        device_type = "iBBQ-4"
+        (temp_1, temp_2, temp_3, temp_4) = unpack("<hhhh", xvalue)
+        result.update(
+            {
+                "temperature probe 1": convert_temperature(temp_1),
+                "temperature probe 2": convert_temperature(temp_2),
+                "temperature probe 3": convert_temperature(temp_3),
+                "temperature probe 4": convert_temperature(temp_4),
             }
         )
     else:

--- a/package/bleparser/oral_b.py
+++ b/package/bleparser/oral_b.py
@@ -52,12 +52,10 @@ SECTORS = {
 def parse_oral_b(self, data, source_mac, rssi):
     """Parser for Oral-B toothbrush."""
     msg_length = len(data)
-    print(data.hex())
     firmware = "Oral-B"
     oral_b_mac = source_mac
     result = {"firmware": firmware}
     if msg_length == 15:
-        print(data[7:15].hex())
         device_type = "SmartSeries 7000"
         (state, pressure, counter, mode, sector, sector_timer, no_of_sectors) = unpack(
             ">BBHBBBB", data[7:15]

--- a/package/bleparser/oral_b.py
+++ b/package/bleparser/oral_b.py
@@ -89,7 +89,7 @@ def parse_oral_b(self, data, source_mac, rssi):
         return None
 
     # check for MAC presence in whitelist, if needed
-    if self.discovery is False and oral_b_mac.lower() not in self.whitelist:
+    if self.discovery is False and oral_b_mac.lower() not in self.sensor_whitelist:
         _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(oral_b_mac))
         return None
 

--- a/package/bleparser/oral_b.py
+++ b/package/bleparser/oral_b.py
@@ -44,6 +44,7 @@ SECTORS = {
     23: "unknown 3",
     47: "unknown 4",
     55: "unknown 5",
+    39: "unknown 6",
     254: "last sector",
     255: "no sector"
 }

--- a/package/bleparser/ruuvitag.py
+++ b/package/bleparser/ruuvitag.py
@@ -9,6 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def parse_ruuvitag(self, data, source_mac, rssi):
+    """Ruuvitag parser"""
     ruuvitag_mac = source_mac
     device_type = "Ruuvitag"
     result = {

--- a/package/bleparser/teltonika.py
+++ b/package/bleparser/teltonika.py
@@ -5,42 +5,41 @@ from struct import unpack
 _LOGGER = logging.getLogger(__name__)
 
 
-def parse_teltonika(self, data, source_mac, rssi):
+def parse_teltonika(self, data, complete_local_name, source_mac, rssi):
     result = {"firmware": "Teltonika"}
     teltonika_mac = source_mac
+    print(data.hex())
+    if complete_local_name == "PUCK_T1":
+        device_type = "Blue Puck T"
+    elif complete_local_name == "PUCK_TH":
+        device_type = "Blue Puck RHT"
+    elif complete_local_name[0:3] == "C T":
+        device_type = "Blue Coin T"
+    elif complete_local_name[0:3] == "P T":
+        device_type = "Blue Puck T"
+    else:
+        device_type = None
 
-    # teltonika adv contain a name (0x09) and one or two 0x16 payloads (temperature/humidity)
-    adpayload_start = 0
-    adpayload_size = len(data)
-    while adpayload_size > 1:
-        adstuct_size = data[adpayload_start] + 1
-        if adstuct_size > 1 and adstuct_size <= adpayload_size:
-            adstruct = data[adpayload_start:adpayload_start + adstuct_size]
-            adstuct_type = adstruct[1]
-            if adstuct_type == 0x09 and adstuct_size > 4:
-                dev_type = adstruct[2:].decode("utf-8")
-                if dev_type == "PUCK_T1":
-                    device_type = "Blue Puck T"
-                elif dev_type == "PUCK_TH":
-                    device_type = "Blue Puck RHT"
-                elif dev_type[0:3] == "C T":
-                    device_type = "Blue Coin T"
-                elif dev_type[0:3] == "P T":
-                    device_type = "Blue Puck T"
-                else:
-                    device_type = None
-            elif adstuct_type == 0x16 and adstuct_size > 4:
-                uuid16 = (adstruct[3] << 8) | adstruct[2]
+    # Teltonika adv contain one or two 0x16 service data packets (temperature/humidity)
+    packet_start = 0
+    data_size = len(data)
+    while data_size > 1:
+        packet_size = data[packet_start] + 1
+        if packet_size > 1 and packet_size <= packet_size:
+            packet = data[packet_start:packet_start + packet_size]
+            packet_type = packet[1]
+            if packet_type == 0x16 and packet_size > 4:
+                uuid16 = (packet[3] << 8) | packet[2]
                 if uuid16 == 0x2A6E:
                     # Temperature
-                    (temp,) = unpack("<h", adstruct[4:])
+                    (temp,) = unpack("<h", packet[4:])
                     result.update({"temperature": temp / 100})
                 elif uuid16 == 0x2A6F:
                     # Humidity
-                    (humi,) = unpack("<B", adstruct[4:])
+                    (humi,) = unpack("<B", packet[4:])
                     result.update({"humidity": humi})
-        adpayload_size -= adstuct_size
-        adpayload_start += adstuct_size
+        data_size -= packet_size
+        packet_start += packet_size
 
     if device_type is None:
         if self.report_unknown == "Teltonika":
@@ -48,7 +47,7 @@ def parse_teltonika(self, data, source_mac, rssi):
                 "BLE ADV from UNKNOWN Teltonika DEVICE: RSSI: %s, MAC: %s, DEVICE TYPE: %s, ADV: %s",
                 rssi,
                 to_mac(source_mac),
-                dev_type,
+                device_type,
                 data.hex()
             )
         return None
@@ -69,4 +68,5 @@ def parse_teltonika(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
+    """Return formatted MAC address"""
     return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/bleparser/thermoplus.py
+++ b/package/bleparser/thermoplus.py
@@ -6,7 +6,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def parse_thermoplus(self, data, source_mac, rssi):
-    # check for adstruc length
+    """Thermoplus parser"""
     msg_length = len(data)
     if msg_length == 22:
         device_id = data[2]
@@ -23,6 +23,7 @@ def parse_thermoplus(self, data, source_mac, rssi):
 
         xvalue = data[12:18]
         (volt, temp, humi) = unpack("<HhH", xvalue)
+        batt = 2500
         if volt >= 3000:
             batt = 100
         elif volt >= 2600:
@@ -73,4 +74,5 @@ def parse_thermoplus(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
+    """Return formatted MAC address"""
     return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/bleparser/xiaogui.py
+++ b/package/bleparser/xiaogui.py
@@ -6,7 +6,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def parse_xiaogui(self, data, source_mac, rssi):
-    """Parser for Xiaogui Scales"""
+    """Xiaogui Scales parser"""
     msg_length = len(data)
 
     if msg_length == 17:

--- a/package/tests/test_govee_parser.py
+++ b/package/tests/test_govee_parser.py
@@ -131,3 +131,20 @@ class TestGovee:
         assert sensor_msg["humidity"] == 60.5
         assert sensor_msg["battery"] == 91
         assert sensor_msg["rssi"] == -74
+
+    def test_Govee_H5183(self):
+        """Test Govee H5183 parser."""
+        data_string = "043e2b02010000edaeac38c1a41f0303518302010511ff5DA1B401000101E400800A2813240000000000000000a9"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Govee"
+        assert sensor_msg["type"] == "H5183"
+        assert sensor_msg["mac"] == "A4C138ACAEED"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature probe 1"] == 26.0
+        assert sensor_msg["temperature alarm"] == 49.0
+        assert sensor_msg["rssi"] == -87

--- a/package/tests/test_inkbird.py
+++ b/package/tests/test_inkbird.py
@@ -24,7 +24,7 @@ class TestInkbird:
 
     def test_inkbird_iBBQ_4_probes(self):
         """Test Inkbird parser for Inkbird iBBQ with 4 probes."""
-        data_string = "043e4a020100001e6771c1e2a83e0201060302f0ff13ff00000000a8e2c171671efa00f6fff6fff6ff050969424251051218003801020a000000000000000000000000000000000000000000b3"
+        data_string = "043e27020100001e6771c1e2a81b0201060302f0ff13ff00000000a8e2c171671e0000000000000000c2"
         data = bytes(bytearray.fromhex(data_string))
 
         # pylint: disable=unused-variable
@@ -36,11 +36,11 @@ class TestInkbird:
         assert sensor_msg["mac"] == "A8E2C171671E"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature probe 1"] == 25.0
+        assert sensor_msg["temperature probe 1"] == 0
         assert sensor_msg["temperature probe 2"] == 0
         assert sensor_msg["temperature probe 3"] == 0
         assert sensor_msg["temperature probe 4"] == 0
-        assert sensor_msg["rssi"] == -77
+        assert sensor_msg["rssi"] == -62
 
     def test_inkbird_IBS_TH2(self):
         """Test Inkbird parser for Inkbird IBS-TH2."""

--- a/package/tests/test_inkbird.py
+++ b/package/tests/test_inkbird.py
@@ -21,3 +21,42 @@ class TestInkbird:
         assert sensor_msg["temperature probe 1"] == 20.0
         assert sensor_msg["temperature probe 2"] == 21.0
         assert sensor_msg["rssi"] == -27
+
+    def test_inkbird_iBBQ_4_probes(self):
+        """Test Inkbird parser for Inkbird iBBQ with 4 probes."""
+        data_string = "043e4a020100001e6771c1e2a83e0201060302f0ff13ff00000000a8e2c171671efa00f6fff6fff6ff050969424251051218003801020a000000000000000000000000000000000000000000b3"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Inkbird"
+        assert sensor_msg["type"] == "iBBQ-4"
+        assert sensor_msg["mac"] == "A8E2C171671E"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature probe 1"] == 25.0
+        assert sensor_msg["temperature probe 2"] == 0
+        assert sensor_msg["temperature probe 3"] == 0
+        assert sensor_msg["temperature probe 4"] == 0
+        assert sensor_msg["rssi"] == -77
+
+    def test_inkbird_IBS_TH2(self):
+        """Test Inkbird parser for Inkbird IBS-TH2."""
+        data_string = "043e1c020104007a63000842491004097370730aff9c08f41000ba4e6408cc"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Inkbird"
+        assert sensor_msg["type"] == "IBS-TH2"
+        assert sensor_msg["mac"] == "49420800637A"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 22.04
+        assert sensor_msg["humidity"] == 43.4
+        assert sensor_msg["battery"] == 100
+        assert sensor_msg["rssi"] == -52

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bleparser
-version = 1.6.0
+version = 1.7.0
 author = Ernst79
 author_email = e.klamer@gmail.com
 description = Parser for passive BLE advertisements


### PR DESCRIPTION
**New sensors**
- Added support for Inkbird IBS-TH2 sensor
- Added support for Inkbird iBBQ-4 sensors
- Added Govee Meat Thermometer (H5183)
- Adding a switch and opening binary sensors to ATC devices

**Bug fixes**
- Fix in whitelist for Oral-B
- Fix for new unknown sector Oral-B

**Improvements**
- Rewrite of the parser, to be able to use more data from different records for filtering (like name, service UUID, etc)