### PR TITLE
April update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ pip install bleparser
 
 Supported sensor brands
 
-- AltBeacon
+- Acconeer
+- Air Mentor
 - ATC (custom firmware for Xiaomi/Qingping sensors)
-- B-parasite
 - BlueMaestro
 - Brifit
+- b-parasite
 - Govee
-- iBeacon
+- HA BLE
+- HHCC
 - Inkbird
 - iNode
 - Jinou
@@ -26,14 +28,17 @@ Supported sensor brands
 - Moat
 - Oral-B
 - Qingping
+- Relsib
 - Ruuvitag
-- SensorPush
 - Sensirion
+- SensorPush
+- Switchbot
 - Teltonika
 - Thermoplus
-- Xiaogui Scale
-- Xiaomi MiBeacon
-- Xiaomi Scale
+- Tilt
+- Xiaogui (Scale)
+- Xiaomi (MiBeacon)
+- Xiaomi (MiScale)
 
 A full list of all supported sensors can be found on the [BLE monitor documentation](https://github.com/custom-components/ble_monitor)
 

--- a/package/bleparser/__init__.py
+++ b/package/bleparser/__init__.py
@@ -1,26 +1,36 @@
 """Parser for passive BLE advertisements."""
 import logging
 
+from .acconeer import parse_acconeer
+from .airmentor import parse_airmentor
 from .altbeacon import parse_altbeacon
 from .atc import parse_atc
 from .bluemaestro import parse_bluemaestro
 from .bparasite import parse_bparasite
 from .brifit import parse_brifit
+from .const import GATT_CHARACTERISTICS, TILT_TYPES
 from .govee import parse_govee
+from .ha_ble import parse_ha_ble
+from .ha_ble_legacy import parse_ha_ble_legacy
+from .hhcc import parse_hhcc
 from .ibeacon import parse_ibeacon
 from .inkbird import parse_inkbird
 from .inode import parse_inode
 from .jinou import parse_jinou
 from .kegtron import parse_kegtron
+from .laica import parse_laica
 from .miscale import parse_miscale
 from .moat import parse_moat
 from .oral_b import parse_oral_b
 from .qingping import parse_qingping
+from .relsib import parse_relsib
 from .ruuvitag import parse_ruuvitag
-from .sensirion import parse_sensirion
 from .sensorpush import parse_sensorpush
+from .sensirion import parse_sensirion
+from .switchbot import parse_switchbot
 from .teltonika import parse_teltonika
 from .thermoplus import parse_thermoplus
+from .tilt import parse_tilt
 from .xiaomi import parse_xiaomi
 from .xiaogui import parse_xiaogui
 
@@ -36,6 +46,7 @@ class BleParser:
         filter_duplicates=False,
         sensor_whitelist=[],
         tracker_whitelist=[],
+        report_unknown_whitelist=[],
         aeskeys={}
     ):
         self.report_unknown = report_unknown
@@ -43,6 +54,7 @@ class BleParser:
         self.filter_duplicates = filter_duplicates
         self.sensor_whitelist = sensor_whitelist
         self.tracker_whitelist = tracker_whitelist
+        self.report_unknown_whitelist = report_unknown_whitelist
         self.aeskeys = aeskeys
 
         self.lpacket_ids = {}
@@ -79,6 +91,7 @@ class BleParser:
         sensor_data = None
         tracker_data = None
         complete_local_name = ""
+        shortened_local_name = ""
         service_class_uuid16 = None
         service_class_uuid128 = None
         service_data_list = []
@@ -100,6 +113,9 @@ class BleParser:
                 elif adstuct_type == 0x06:
                     # AD type '128-bit Service Class UUIDs'
                     service_class_uuid128 = adstruct[2:]
+                elif adstuct_type == 0x08:
+                    # AD type 'shortened local name'
+                    shortened_local_name = adstruct[2:].decode("utf-8")
                 elif adstuct_type == 0x09:
                     # AD type 'complete local name'
                     complete_local_name = adstruct[2:].decode("utf-8")
@@ -118,26 +134,55 @@ class BleParser:
                 for service_data in service_data_list:
                     # parse data for sensors with service data
                     uuid16 = (service_data[3] << 8) | service_data[2]
-                    if uuid16 == 0xFFF9 or uuid16 == 0xFDCD:  # UUID16 = Cleargrass or Qingping
-                        sensor_data = parse_qingping(self, service_data, mac, rssi)
-                        break
-                    elif uuid16 == 0x181A:  # UUID16 = ATC or b-parasite
+                    if uuid16 == 0x181A:
+                        # UUID16 = Environmental Sensing (used by ATC or b-parasite)
                         if len(service_data) == 22 or len(service_data) == 20:
                             sensor_data = parse_bparasite(self, service_data, mac, rssi)
                         else:
                             sensor_data = parse_atc(self, service_data, mac, rssi)
                         break
-                    elif uuid16 == 0xFE95:  # UUID16 = Xiaomi
-                        sensor_data = parse_xiaomi(self, service_data, mac, rssi)
-                        break
-                    elif uuid16 == 0x181D or uuid16 == 0x181B:  # UUID16 = Mi Scale
+                    elif uuid16 in [0x181B, 0x181D]:
+                        # UUID16 = Body Composition and Weight Scale (used by Mi Scale)
                         sensor_data = parse_miscale(self, service_data, mac, rssi)
                         break
-                    elif uuid16 == 0xFEAA:  # UUID16 = Ruuvitag V2/V4
+                    elif uuid16 in [0x181C, 0x181E]:
+                        # UUID16 = User Data and Bond Management (used by BLE HA)
+                        sensor_data = parse_ha_ble(self, service_data, uuid16, mac, rssi)
+                        break
+                    elif uuid16 in [0xAA20, 0xAA21, 0xAA22] and complete_local_name == "ECo":
+                        # UUID16 = Relsib
+                        sensor_data = parse_relsib(self, service_data, mac, rssi)
+                        break
+                    elif uuid16 in [0xFD3D, 0x0D00]:
+                        # UUID16 = unknown (used by Switchbot)
+                        sensor_data = parse_switchbot(self, service_data, mac, rssi)
+                        break
+                    elif uuid16 == 0xFD50:
+                        # UUID16 = Hangzhou Tuya Information Technology Co., Ltd (HHCC)
+                        sensor_data = parse_hhcc(self, service_data, mac, rssi)
+                        break
+                    elif uuid16 == 0xFDCD:
+                        # UUID16 = Qingping
+                        sensor_data = parse_qingping(self, service_data, mac, rssi)
+                        break
+                    elif uuid16 == 0xFE95:
+                        # UUID16 = Xiaomi
+                        sensor_data = parse_xiaomi(self, service_data, mac, rssi)
+                        break
+                    elif uuid16 == 0xFEAA:
+                        # UUID16 = Google (used by Ruuvitag V2/V4)
                         sensor_data = parse_ruuvitag(self, service_data, mac, rssi)
                         break
-                    elif uuid16 == 0x2A6E or uuid16 == 0x2A6F:  # UUID16 = Teltonika
-                        # Teltonika can contain multiple service data payloads in one advertisement
+                    elif uuid16 == 0xFFF9:
+                        # UUID16 = FIDO (used by Cleargrass)
+                        sensor_data = parse_qingping(self, service_data, mac, rssi)
+                        break
+                    elif uuid16 in GATT_CHARACTERISTICS and shortened_local_name == "HA_BLE":
+                        # HA BLE legacy (deprecated)
+                        sensor_data = parse_ha_ble_legacy(self, service_data_list, mac, rssi)
+                        break
+                    elif uuid16 == 0x2A6E or uuid16 == 0x2A6F:
+                        # UUID16 = Temperature and Humidity (used by Teltonika)
                         if len(service_data_list) == 2:
                             service_data = b"".join(service_data_list)
                         sensor_data = parse_teltonika(self, service_data, complete_local_name, mac, rssi)
@@ -148,75 +193,125 @@ class BleParser:
                 for man_spec_data in man_spec_data_list:
                     # parse data for sensors with manufacturer specific data
                     comp_id = (man_spec_data[3] << 8) | man_spec_data[2]
-                    if comp_id == 0x4C and man_spec_data[4] == 0x02:  # iBeacon
-                        sensor_data, tracker_data = parse_ibeacon(self, man_spec_data, mac, rssi)
+                    data_len = man_spec_data[0]
+                    # Filter on Company Identifier
+                    if comp_id == 0x0001 and data_len in [0x09, 0x0C]:
+                        # Govee H5101/H5102/H5177
+                        sensor_data = parse_govee(self, man_spec_data, mac, rssi)
                         break
-                    elif man_spec_data[0] == 0x1B and ((man_spec_data[4] << 8) | man_spec_data[5]) == 0xBEAC:  # AltBeacon
-                        sensor_data, tracker_data = parse_altbeacon(self, man_spec_data, comp_id, mac, rssi)
+                    elif comp_id == 0x004C and man_spec_data[4] == 0x02:
+                        # iBeacon
+                        if int.from_bytes(man_spec_data[6:22], byteorder='big') in TILT_TYPES:
+                            sensor_data, tracker_data = parse_tilt(self, man_spec_data, mac, rssi)
+                        else:
+                            sensor_data, tracker_data = parse_ibeacon(self, man_spec_data, mac, rssi)
                         break
-                    elif man_spec_data[0] == 0x1E and comp_id == 0xFFFF:  # Kegtron
+                    elif comp_id == 0x00DC and data_len == 0x0E:
+                        # Oral-b
+                        sensor_data = parse_oral_b(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0x0499:
+                        # Ruuvitag V3/V5
+                        sensor_data = parse_ruuvitag(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0x1000 and data_len == 0x15:
+                        # Moat S2
+                        sensor_data = parse_moat(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0x0133 and data_len == 0x11:
+                        # BlueMaestro
+                        sensor_data = parse_bluemaestro(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0x06D5:
+                        # Sensirion
+                        sensor_data = parse_sensirion(self, man_spec_data, complete_local_name, mac, rssi)
+                        break
+                    elif comp_id in [0x2121, 0x2122] and data_len == 0x0B:
+                        # Air Mentor
+                        sensor_data = parse_airmentor(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0x8801 and data_len == 0x0C:
+                        # Govee H5179
+                        sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0xAA55 and data_len == 0x14:
+                        # Brifit
+                        sensor_data = parse_brifit(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0xEC88 and data_len in [0x09, 0x0A, 0x0C]:
+                        # Govee H5051/H5071/H5072/H5075/H5074
+                        sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                        break
+                    elif comp_id == 0xFFFF and data_len == 0x1E:
+                        # Kegtron
                         sensor_data = parse_kegtron(self, man_spec_data, mac, rssi)
                         break
+                    elif comp_id == 0xA0AC and data_len == 0x0F and man_spec_data[14] in [0x06, 0x0D]:
+                        # Laica
+                        sensor_data = parse_laica(self, man_spec_data, mac, rssi)
+                        break
+
+                    # Filter on part of the UUID16
+                    elif man_spec_data[2] == 0xC0 and data_len == 0x10:
+                        # Xiaogui Scale
+                        sensor_data = parse_xiaogui(self, man_spec_data, mac, rssi)
+                        break
+                    elif man_spec_data[3] == 0x82 and data_len == 0x0E:
+                        # iNode
+                        sensor_data = parse_inode(self, man_spec_data, mac, rssi)
+                        break
+                    elif man_spec_data[3] in [
+                        0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x9A, 0x9B, 0x9C, 0x9D
+                    ] and data_len == 0x19:
+                        # iNode Care Sensors
+                        sensor_data = parse_inode(self, man_spec_data, mac, rssi)
+                        break
+
+                    # Filter on service class uuid16
+                    elif service_class_uuid16 == 0x20AA and data_len == 0x0E:
+                        # Jinou BEC07-5
+                        sensor_data = parse_jinou(self, man_spec_data, mac, rssi)
+                        break
+                    elif service_class_uuid16 == 0x5183 and data_len == 0x11:
+                        # Govee H5183
+                        sensor_data = parse_govee(self, man_spec_data, mac, rssi)
+                        break
                     elif service_class_uuid16 == 0xF0FF:
-                        if man_spec_data[0] in [0x15, 0x17] and comp_id in [0x0010, 0x0011, 0x0015]:  # Thermoplus
+                        if comp_id in [0x0010, 0x0011, 0x0015] and data_len in [0x15, 0x17]:
+                            # Thermoplus
                             sensor_data = parse_thermoplus(self, man_spec_data, mac, rssi)
                             break
-                        elif man_spec_data[0] in [0x0D, 0x0F, 0x13, 0x17] and (
-                            comp_id in [0x0000, 0x0001] or complete_local_name == "iBBQ"
-                        ):  # Inkbird iBBQ
-                            sensor_data = parse_inkbird(self, man_spec_data, mac, rssi)
+                        elif (comp_id in [0x0000, 0x0001] or complete_local_name in ["iBBQ", "sps", "tps"]) and (
+                            data_len in [0x0A, 0x0D, 0x0F, 0x13, 0x17]
+                        ):
+                            # Inkbird
+                            sensor_data = parse_inkbird(self, man_spec_data, complete_local_name, mac, rssi)
                             break
                         else:
                             unknown_sensor = True
-                    elif man_spec_data[0] == 0x0A and complete_local_name == "sps":  # Inkbird IBS-TH
-                        sensor_data = parse_inkbird(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] in [0x09, 0x0A, 0x0C] and comp_id == 0xEC88:  # Govee H5051/H5072/H5075/H5074
-                        sensor_data = parse_govee(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] in [0x09, 0x0C] and comp_id == 0x0001:  # Govee H5101/H5102/H5177
-                        sensor_data = parse_govee(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x0C and comp_id == 0x8801:  # Govee H5179
-                        sensor_data = parse_govee(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x11 and service_class_uuid16 == 0x5183:  # Govee H5183
-                        sensor_data = parse_govee(self, man_spec_data, mac, rssi)
-                        break
-                    elif comp_id == 0x0499:  # Ruuvitag V3/V5
-                        sensor_data = parse_ruuvitag(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x14 and (comp_id == 0xaa55):  # Brifit
-                        sensor_data = parse_brifit(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x0E and man_spec_data[3] == 0x82:  # iNode
-                        sensor_data = parse_inode(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x19 and man_spec_data[3] in [
-                        0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x9A, 0x9B, 0x9C, 0x9D
-                    ]:  # iNode Care Sensors
-                        sensor_data = parse_inode(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x0E and service_class_uuid16 == 0x20AA:  # Jinou BEC07-5
-                        sensor_data = parse_jinou(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x15 and comp_id == 0x1000:  # Moat S2
-                        sensor_data = parse_moat(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x11 and comp_id == 0x0133:  # BlueMaestro
-                        sensor_data = parse_bluemaestro(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x10 and adstruct[2] == 0xC0:  # Xiaogui Scale
-                        sensor_data = parse_xiaogui(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] == 0x0E and comp_id == 0x00DC:  # Oral-b
-                        sensor_data = parse_oral_b(self, man_spec_data, mac, rssi)
-                        break
-                    elif man_spec_data[0] in [0x06, 0x08] and service_class_uuid128 == b'\xb0\x0a\x09\xec\xd7\x9d\xb8\x93\xba\x42\xd6\x11\x00\x00\x09\xef':  # Sensorpush
+
+                    # Filter on service class uuid128
+                    elif service_class_uuid128 == (
+                        b'\xb0\x0a\x09\xec\xd7\x9d\xb8\x93\xba\x42\xd6\x11\x00\x00\x09\xef'
+                    ) and data_len in [0x06, 0x08]:
+                        # Sensorpush
                         sensor_data = parse_sensorpush(self, man_spec_data, mac, rssi)
                         break
-                    elif comp_id == 0x06D5:  # Sensirion
-                        sensor_data = parse_sensirion(self, man_spec_data, complete_local_name, mac, rssi)
+
+                    # Filter on complete local name
+                    elif complete_local_name in ["sps", "tps"] and data_len == 0x0A:
+                        # Inkbird IBS-TH
+                        sensor_data = parse_inkbird(self, man_spec_data, complete_local_name, mac, rssi)
+                        break
+
+                    # Filter on other parts of the manufacturer specific data
+                    elif data_len == 0x1B and ((man_spec_data[4] << 8) | man_spec_data[5]) == 0xBEAC:
+                        # AltBeacon
+                        sensor_data, tracker_data = parse_altbeacon(self, man_spec_data, comp_id, mac, rssi)
+                        break
+
+                    elif man_spec_data[0] == 0x12 and comp_id == 0xACC0:  # Acconeer
+                        sensor_data = parse_acconeer(self, man_spec_data, mac, rssi)
                         break
                     else:
                         unknown_sensor = True
@@ -239,5 +334,9 @@ class BleParser:
                 }
         else:
             tracker_data = None
+
+        if self.report_unknown_whitelist:
+            if tracker_id in self.report_unknown_whitelist:
+                _LOGGER.info("BLE advertisement received from MAC/UUID %s: %s", tracker_id.hex(), data.hex())
 
         return sensor_data, tracker_data

--- a/package/bleparser/acconeer.py
+++ b/package/bleparser/acconeer.py
@@ -1,0 +1,93 @@
+"""Parser for Acconeer BLE advertisements"""
+import logging
+from struct import unpack
+
+_LOGGER = logging.getLogger(__name__)
+
+ACCONEER_SENSOR_IDS = {
+    0x80: "Acconeer XM122"
+}
+
+MEASUREMENTS = {
+    0x80: ["presence", "temperature"],
+}
+
+
+def parse_acconeer(self, data, source_mac, rssi):
+    """Acconeer parser"""
+    msg_length = len(data)
+    firmware = "Acconeer"
+    acconeer_mac = source_mac
+    device_id = data[4]
+    xvalue = data[5:]
+    result = {"firmware": firmware}
+
+    if msg_length == 19 and device_id in ACCONEER_SENSOR_IDS:
+        """Acconeer Sensors"""
+        device_type = ACCONEER_SENSOR_IDS[device_id]
+        measurements = MEASUREMENTS[device_id]
+        (
+            battery_level,
+            temperature,
+            presence,
+            reserved2
+        ) = unpack("<HhHQ", xvalue)
+
+        if "presence" in measurements:
+            result.update({
+                "motion": 0 if presence == 0 else 1,
+            })
+
+        if "temperature" in measurements:
+            result.update({
+                "temperature": temperature,
+            })
+
+        result.update({
+                "battery": battery_level,
+        })
+    else:
+        device_type = None
+
+    if device_type is None:
+        if self.report_unknown == "Acconeer":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Acconeer DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+
+    # Check for duplicate messages
+    packet_id = xvalue.hex()
+    try:
+        prev_packet = self.lpacket_ids[acconeer_mac]
+    except KeyError:
+        # start with empty first packet
+        prev_packet = None
+    if prev_packet == packet_id:
+        # only process new messages
+        if self.filter_duplicates is True:
+            return None
+    self.lpacket_ids[acconeer_mac] = packet_id
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and acconeer_mac not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(acconeer_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join('{:02X}'.format(x) for x in acconeer_mac[:]),
+        "type": device_type,
+        "packet": packet_id,
+        "firmware": firmware,
+        "data": True
+    })
+    return result
+
+
+def to_mac(addr: int):
+    """Return formatted MAC address"""
+    return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/bleparser/airmentor.py
+++ b/package/bleparser/airmentor.py
@@ -1,0 +1,83 @@
+"""Parser for Air Mentor BLE advertisements"""
+import logging
+from struct import unpack
+import math
+
+from .helpers import (
+    to_mac,
+    to_unformatted_mac,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_airmentor(self, data, source_mac, rssi):
+    """Parser for Air Mentor"""
+    data_length = len(data)
+    if data_length == 12:
+        device_type = "Air Mentor Pro 2"
+        firmware = "Air Mentor"
+        airmentor_mac = source_mac
+        msg_type = data[2]
+        xvalue = data[4:]
+        if msg_type == 0x22:
+            (tvoc, temp, temp_cal, humi, aqi) = unpack(">HHBBH", xvalue)
+            temperature = (temp - 4000) * 0.01
+            temperature_calibrated = temperature - temp_cal * 0.1
+            humi = round(float(int("0x2d", 16)) * math.exp(temperature * 17.62 / (temperature + 243.12)) / math.exp(
+                temperature_calibrated * 17.62 / (temperature_calibrated + 243.12)), 2
+            )
+            if aqi <= 50:
+                air_quality = "good"
+            elif aqi <= 100:
+                air_quality = "moderate"
+            elif aqi <= 150:
+                air_quality = "unhealthy for sensitive people"
+            elif aqi <= 200:
+                air_quality = "unhealthy"
+            elif aqi <= 250:
+                air_quality = "very unhealthy"
+            else:
+                air_quality = "hazardous"
+            result = {
+                "tvoc": tvoc,
+                "temperature": round(temperature, 2),
+                "temperature calibrated": round(temperature_calibrated, 2),
+                "humidity": round(humi, 2),
+                "aqi": aqi,
+                "air quality": air_quality
+            }
+        if msg_type == 0x21:
+            (co2, pm25, pm10, co, o3) = unpack(">HHHBB", xvalue)
+            # CO and O3 are not used
+            result = {
+                "co2": co2,
+                "pm2.5": pm25,
+                "pm10": pm10,
+            }
+    else:
+        device_type = None
+    if device_type is None:
+        if self.report_unknown == "Air Mentor":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Air Mentor DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and airmentor_mac.lower() not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(airmentor_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": to_unformatted_mac(airmentor_mac),
+        "type": device_type,
+        "packet": "no packet id",
+        "firmware": firmware,
+        "data": True
+    })
+    return result

--- a/package/bleparser/altbeacon.py
+++ b/package/bleparser/altbeacon.py
@@ -1,7 +1,6 @@
 """Parser for AltBeacon BLE advertisements"""
 import logging
 from struct import unpack
-from uuid import UUID
 from typing import Final
 
 from .const import (
@@ -21,19 +20,26 @@ from .const import (
     MANUFACTURER_DICT,
     DEFAULT_MANUFACTURER,
 )
+from .helpers import (
+    to_mac,
+    to_uuid,
+    to_unformatted_mac,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 DEVICE_TYPE: Final = "AltBeacon"
 
+
 def parse_altbeacon(self, data: str, comp_id: int, source_mac: str, rssi: float):
+    """parser for Alt Beacon"""
     if len(data) >= 27:
         uuid = data[6:22]
         (major, minor, power) = unpack(">HHb", data[22:27])
 
         tracker_data = {
             CONF_RSSI: rssi,
-            CONF_MAC: to_mac(source_mac),
+            CONF_MAC: to_unformatted_mac(source_mac),
             CONF_UUID: to_uuid(uuid).replace('-', ''),
             CONF_TRACKER_ID: uuid,
             CONF_MAJOR: major,
@@ -68,11 +74,3 @@ def parse_altbeacon(self, data: str, comp_id: int, source_mac: str, rssi: float)
         return None, None
 
     return sensor_data, tracker_data
-
-
-def to_uuid(uuid: str) -> str:
-    return str(UUID(''.join('{:02X}'.format(x) for x in uuid)))
-
-
-def to_mac(addr: str) -> str:
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/bleparser/atc.py
+++ b/package/bleparser/atc.py
@@ -3,11 +3,16 @@ import logging
 from struct import unpack
 from Cryptodome.Cipher import AES
 
+from .helpers import (
+    to_mac,
+    to_unformatted_mac,
+)
+
 _LOGGER = logging.getLogger(__name__)
 
 
 def parse_atc(self, data, source_mac, rssi):
-    """Check for adstruc length"""
+    """Parse ATC BLE advertisements"""
     device_type = "ATC"
     msg_length = len(data)
     if msg_length == 19:
@@ -132,7 +137,7 @@ def parse_atc(self, data, source_mac, rssi):
 
     result.update({
         "rssi": rssi,
-        "mac": ''.join('{:02X}'.format(x) for x in atc_mac),
+        "mac": to_unformatted_mac(atc_mac),
         "type": device_type,
         "packet": packet_id,
         "firmware": firmware
@@ -175,8 +180,3 @@ def decrypt_atc(self, data, atc_mac):
         return None
 
     return decrypted_payload
-
-
-def to_mac(addr: int):
-    """Convert MAC address."""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/bleparser/bluemaestro.py
+++ b/package/bleparser/bluemaestro.py
@@ -61,5 +61,5 @@ def parse_bluemaestro(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
-    """Convert MAC address."""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/bparasite.py
+++ b/package/bleparser/bparasite.py
@@ -8,13 +8,13 @@ _LOGGER = logging.getLogger(__name__)
 def parse_bparasite(self, data, source_mac, rssi):
     """Check for adstruc length"""
     msg_length = len(data)
-    if msg_length == 22:  # TODO: Use version bits?
+    if msg_length == 22:  # TODO: Use protocol bits?
         bpara_mac = data[14:20]
         device_type = "b-parasite V1.1.0"
         firmware = "b-parasite V1.1.0 (with illuminance)"
-        (protocol, packet_id, batt, temp, humi, moist, mac, light) = unpack(">BBHHHH6sH", data[4:])
+        (protocol, packet_id, batt, temp, humi, moist, mac, light) = unpack(">BBHhHH6sH", data[4:])
         result = {
-            "temperature": temp / 1000,
+            "temperature": temp / (100 if (protocol >> 4) == 2 else 1000),
             "humidity": (humi / 65536) * 100,
             "voltage": batt / 1000.0,
             "moisture": (moist / 65536) * 100,
@@ -25,9 +25,9 @@ def parse_bparasite(self, data, source_mac, rssi):
         bpara_mac = data[14:20]
         device_type = "b-parasite V1.0.0"
         firmware = "b-parasite V1.0.0 (without illuminance)"
-        (protocol, packet_id, batt, temp, humi, moist, mac) = unpack(">BBHHHH6s", data[4:])
+        (protocol, packet_id, batt, temp, humi, moist, mac) = unpack(">BBHhHH6s", data[4:])
         result = {
-            "temperature": temp / 1000,
+            "temperature": temp / (100 if (protocol >> 4) == 2 else 1000),
             "humidity": (humi / 65536) * 100,
             "voltage": batt / 1000.0,
             "moisture": (moist / 65536) * 100,
@@ -63,7 +63,7 @@ def parse_bparasite(self, data, source_mac, rssi):
 
     result.update({
         "rssi": rssi,
-        "mac": ''.join('{:02X}'.format(x) for x in bpara_mac),
+        "mac": ''.join('{:02X}'.format(x) for x in bpara_mac[:]),
         "type": device_type,
         "packet": packet_id,
         "firmware": firmware,

--- a/package/bleparser/brifit.py
+++ b/package/bleparser/brifit.py
@@ -1,4 +1,4 @@
-# Parser for Brifit BLE advertisements
+"""Parser for Brifit BLE advertisements"""
 import logging
 from struct import unpack
 
@@ -6,7 +6,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def parse_brifit(self, data, source_mac, rssi):
-    # check for adstruc length
+    """Parser for Brifit sensors"""
     msg_length = len(data)
     if msg_length == 21:
         device_id = data[2]
@@ -59,4 +59,5 @@ def parse_brifit(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/const.py
+++ b/package/bleparser/const.py
@@ -8,15 +8,41 @@ CONF_DATA: Final = "data"
 CONF_MANUFACTURER: Final = "manufacturer"
 CONF_RSSI: Final = "rssi"
 
-CONF_UUID: Final = "uuid"
-CONF_TRACKER_ID: Final = "tracker_id"
-CONF_MAJOR: Final = "major"
-CONF_MINOR: Final = "minor"
-CONF_MEASURED_POWER: Final = "measured power"
-CONF_CYPRESS_TEMPERATURE: Final = "cypress temperature"
+CONF_BATTERY: Final = "battery"
+CONF_CONDUCTIVITY: Final = "conductivity"
 CONF_CYPRESS_HUMIDITY: Final = "cypress humidity"
+CONF_CYPRESS_TEMPERATURE: Final = "cypress temperature"
+CONF_GRAVITY: Final = "gravity"
+CONF_HUMIDITY: Final = "humidity"
+CONF_ILLUMINANCE: Final = "illuminance"
+CONF_MAJOR: Final = "major"
+CONF_MEASURED_POWER: Final = "measured power"
+CONF_MINOR: Final = "minor"
+CONF_MOISTURE: Final = "moisture"
+CONF_TEMPERATURE: Final = "temperature"
+CONF_TRACKER_ID: Final = "tracker_id"
+CONF_UUID: Final = "uuid"
 
 DEFAULT_MANUFACTURER: Final = "Other"
+
+GATT_CHARACTERISTICS: Final = {
+    0x2A4D: "packet id",
+    0x2A19: "battery",
+    0x2A6D: "pressure",
+    0x2A6E: "temperature",
+    0x2A6F: "humidity",
+    0x2A7B: "dewpoint",
+    0x2A98: "weight",
+    0x2AE2: "binary",
+    0x2AEA: "count",
+    0x2AEB: "count",
+    0X2AF2: "energy",
+    0X2AFB: "illuminance",
+    0x2B05: "power",
+    0x2B18: "voltage",
+    0x2BD6: "pm2.5",
+    0x2BD7: "pm10",
+}
 
 MANUFACTURER_DICT: Final = {
     0x0000: "Ericsson Technology Licensing",
@@ -556,4 +582,16 @@ MANUFACTURER_DICT: Final = {
     0x0217: "Tech4home, Lda",
     0x0218: "Hiotech AB",
     0x06D5: "Sensirion AG",
+}
+
+
+TILT_TYPES: Final = {
+    0xA495BB10C5B14B44B5121370F02D74DE: "Red",
+    0xA495BB20C5B14B44B5121370F02D74DE: "Green",
+    0xA495BB30C5B14B44B5121370F02D74DE: "Black",
+    0xA495BB40C5B14B44B5121370F02D74DE: "Purple",
+    0xA495BB50C5B14B44B5121370F02D74DE: "Orange",
+    0xA495BB60C5B14B44B5121370F02D74DE: "Blue",
+    0xA495BB70C5B14B44B5121370F02D74DE: "Yellow",
+    0xA495BB80C5B14B44B5121370F02D74DE: "Pink",
 }

--- a/package/bleparser/govee.py
+++ b/package/bleparser/govee.py
@@ -1,4 +1,4 @@
-# Parser for Govee BLE advertisements
+"""Parser for Govee BLE advertisements"""
 import logging
 from struct import unpack
 
@@ -14,7 +14,7 @@ def decode_temps(packet_value: int) -> float:
 
 
 def parse_govee(self, data, source_mac, rssi):
-    # check for adstruc length
+    """Parser for Govee sensors"""
     msg_length = len(data)
     firmware = "Govee"
     govee_mac = source_mac
@@ -41,7 +41,7 @@ def parse_govee(self, data, source_mac, rssi):
         (temp, humi, batt) = unpack("<hHB", data[5:10])
         result.update({"temperature": temp / 100, "humidity": humi / 100, "battery": batt})
     elif msg_length == 13 and device_id == 0xEC88:
-        device_type = "H5051"
+        device_type = "H5051/H5071"
         (temp, humi, batt) = unpack("<hHB", data[5:10])
         result.update({"temperature": temp / 100, "humidity": humi / 100, "battery": batt})
     elif msg_length == 13 and device_id == 0x0001:
@@ -109,4 +109,5 @@ def parse_govee(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    """Convert MAC address."""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/ha_ble.py
+++ b/package/bleparser/ha_ble.py
@@ -1,0 +1,228 @@
+"""Parser for HA BLE (DIY sensors) advertisements"""
+import logging
+import struct
+from Cryptodome.Cipher import AES
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_uint(data_obj, factor=1):
+    """convert bytes (as unsigned integer) and factor to float"""
+    decimal_places = -int(f'{factor:e}'.split('e')[-1])
+    return round(int.from_bytes(data_obj, "little", signed=False) * factor, decimal_places)
+
+
+def parse_int(data_obj, factor=1):
+    """convert bytes (as signed integer) and factor to float"""
+    decimal_places = -int(f'{factor:e}'.split('e')[-1])
+    return round(int.from_bytes(data_obj, "little", signed=True) * factor, decimal_places)
+
+
+def parse_float(data_obj, factor=1):
+    """convert bytes (as float) and factor to float"""
+    decimal_places = -int(f'{factor:e}'.split('e')[-1])
+    if len(data_obj) == 2:
+        [val] = struct.unpack('e', data_obj)
+    if len(data_obj) == 4:
+        [val] = struct.unpack('f', data_obj)
+    elif len(data_obj) == 8:
+        [val] = struct.unpack('d', data_obj)
+    else:
+        _LOGGER.error("only 2, 4 or 8 byte long floats are supported in HA BLE")
+        return None
+    return round(val * factor, decimal_places)
+
+
+def parse_string(data_obj, factor=None):
+    """convert bytes to string"""
+    return data_obj.decode('UTF-8')
+
+
+def parse_mac(data_obj):
+    """convert bytes to mac"""
+    if len(data_obj) == 6:
+        return data_obj[::-1]
+    else:
+        _LOGGER.error("MAC address has to be 6 bytes long")
+        return None
+
+
+dispatch = {
+    0x00: parse_uint,
+    0x01: parse_int,
+    0x02: parse_float,
+    0x03: parse_string,
+    0x04: parse_mac,
+}
+
+DATA_MEAS_DICT = {
+    0x00: ["packet", 1],
+    0x01: ["battery", 1],
+    0x02: ["temperature", 0.01],
+    0x03: ["humidity", 0.01],
+    0x04: ["pressure", 0.01],
+    0x05: ["illuminance", 0.01],
+    0x06: ["weight", 0.01],
+    0x07: ["weight unit", None],
+    0x08: ["dewpoint", 0.01],
+    0x09: ["count", 1],
+    0x0A: ["energy", 0.001],
+    0x0B: ["power", 0.01],
+    0x0C: ["voltage", 0.001],
+    0x0D: ["pm2.5", 1],
+    0x0E: ["pm10", 1],
+    0x0F: ["binary", 1],
+    0x10: ["switch", 1],
+    0x11: ["opening", 1],
+}
+
+
+def parse_ha_ble(self, data, uuid16, source_mac, rssi):
+    """Home Assistant BLE parser"""
+    device_type = "HA BLE DIY"
+    ha_ble_mac = source_mac
+    result = {}
+    packet_id = None
+
+    if uuid16 == 0x181C:
+        # Non-encrypted HA BLE format
+        payload = data[4:]
+        firmware = "HA BLE"
+        packet_id = None
+    elif uuid16 == 0x181E:
+        # Encrypted HA BLE format
+        payload, count_id = decrypt_data(self, data, ha_ble_mac)
+        firmware = "HA BLE (encrypted)"
+        if count_id:
+            packet_id = parse_uint(count_id)
+    else:
+        return None
+
+    if payload:
+        payload_length = len(payload)
+        payload_start = 0
+    else:
+        return None
+
+    payload_length = len(payload)
+    payload_start = 0
+
+    while payload_length >= payload_start + 1:
+        obj_control_byte = payload[payload_start]
+        obj_data_length = (obj_control_byte >> 0) & 31  # 5 bits (0-4)
+        obj_data_format = (obj_control_byte >> 5) & 7  # 3 bits (5-7)
+        obj_meas_type = payload[payload_start + 1]
+        next_start = payload_start + 1 + obj_data_length
+        if payload_length < next_start:
+            _LOGGER.debug("Invalid payload data length, payload: %s", payload.hex())
+            break
+
+        if obj_data_length != 0:
+            if obj_data_format <= 3:
+                if obj_meas_type in DATA_MEAS_DICT:
+                    meas_data = payload[payload_start + 2:next_start]
+                    meas_type = DATA_MEAS_DICT[obj_meas_type][0]
+                    meas_factor = DATA_MEAS_DICT[obj_meas_type][1]
+                    meas = dispatch[obj_data_format](meas_data, meas_factor)
+                    result.update({meas_type: meas})
+                else:
+                    if self.report_unknown == "HA BLE":
+                        _LOGGER.error("UNKNOWN dataobject in HA BLE payload! Adv: %s", data.hex())
+            elif obj_data_format == 4:
+                data_mac = dispatch[obj_data_format](payload[payload_start + 1:next_start])
+                if data_mac:
+                    ha_ble_mac = data_mac
+            else:
+                if self.report_unknown == "HA BLE":
+                    _LOGGER.error("UNKNOWN dataobject in HA BLE payload! Adv: %s", data.hex())
+        payload_start = next_start
+
+    if not result:
+        if self.report_unknown == "HA BLE":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Home Assistant BLE DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+
+    # Check for packet id in payload
+    if result.get("packet"):
+        packet_id = result["packet"]
+
+    # Check for duplicate messages
+    if packet_id:
+        try:
+            prev_packet = self.lpacket_ids[ha_ble_mac]
+        except KeyError:
+            # start with empty first packet
+            prev_packet = None
+        if prev_packet == packet_id:
+            # only process new messages
+            if self.filter_duplicates is True:
+                return None
+        self.lpacket_ids[ha_ble_mac] = packet_id
+    else:
+        packet_id = "no packet id"
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and ha_ble_mac not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(ha_ble_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join(f'{i:02X}' for i in ha_ble_mac),
+        "packet": packet_id,
+        "type": device_type,
+        "firmware": firmware,
+        "data": True
+    })
+    return result
+
+
+def decrypt_data(self, data, ha_ble_mac):
+    """Decrypt encrypted HA BLE advertisements"""
+    # check for minimum length of encrypted advertisement
+    if len(data) < 15:
+        _LOGGER.debug("Invalid data length (for decryption), adv: %s", data.hex())
+    # try to find encryption key for current device
+    try:
+        key = self.aeskeys[ha_ble_mac]
+        if len(key) != 16:
+            _LOGGER.error("Encryption key should be 16 bytes (32 characters) long")
+            return None, None
+    except KeyError:
+        # no encryption key found
+        _LOGGER.error("No encryption key found for device with MAC %s", to_mac(ha_ble_mac))
+        return None, None
+    uuid = data[2:4]
+    encrypted_payload = data[4:-8]
+    count_id = data[-8:-4]
+    mic = data[-4:]
+
+    # nonce: mac [6], uuid16 [2], count_id [4] (6+2+4 = 12 bytes)
+    nonce = b"".join([ha_ble_mac, uuid, count_id])
+    cipher = AES.new(key, AES.MODE_CCM, nonce=nonce, mac_len=4)
+    cipher.update(b"\x11")
+    try:
+        decrypted_payload = cipher.decrypt_and_verify(encrypted_payload, mic)
+    except ValueError as error:
+        _LOGGER.warning("Decryption failed: %s", error)
+        _LOGGER.debug("mic: %s", mic.hex())
+        _LOGGER.debug("nonce: %s", nonce.hex())
+        _LOGGER.debug("encrypted_payload: %s", encrypted_payload.hex())
+        return None
+    if decrypted_payload is None:
+        _LOGGER.error(
+            "Decryption failed for %s, decrypted payload is None",
+            to_mac(ha_ble_mac),
+        )
+        return None, None
+    return decrypted_payload, count_id
+
+
+def to_mac(addr: int):
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/ha_ble_encryption.py
+++ b/package/bleparser/ha_ble_encryption.py
@@ -1,0 +1,89 @@
+"""Example showing encoding and decoding of HA BLE advertisement"""
+import binascii
+from Cryptodome.Cipher import AES
+
+
+def parse_value(hexvalue):
+    """Parse decrypted payload to readable HA BLE data"""
+    vlength = len(hexvalue)
+    if vlength >= 3:
+        temp = round(int.from_bytes(hexvalue[2:4], "little", signed=False) * 0.01, 2)
+        humi = round(int.from_bytes(hexvalue[6:8], "little", signed=False) * 0.01, 2)
+        print("Temperature:", temp, "Humidity:", humi)
+        return 1
+    print("MsgLength:", vlength, "HexValue:", hexvalue.hex())
+    return None
+
+
+def decrypt_payload(payload, mic, key, nonce):
+    """Decrypt payload."""
+    print("Nonce:", nonce.hex())
+    print("CryptData:", payload.hex(), "Mic:", mic.hex())
+    cipher = AES.new(key, AES.MODE_CCM, nonce=nonce, mac_len=4)
+    cipher.update(b"\x11")
+    try:
+        data = cipher.decrypt_and_verify(payload, mic)
+    except ValueError as error:
+        print("Decryption failed:", error)
+        return None
+    print("DecryptData:", data.hex())
+    print()
+    if parse_value(data) is not None:
+        return 1
+    print('??')
+    return None
+
+
+def decrypt_aes_ccm(key, mac, data):
+    """Decrypt AES CCM."""
+    print("MAC:", mac.hex(), "Bindkey:", key.hex())
+    print()
+    adslength = len(data)
+    if adslength > 15 and data[0] == 0x1E and data[1] == 0x18:
+        pkt = data[:data[0] + 1]
+        uuid = pkt[0:2]
+        encrypted_data = pkt[2:-8]
+        count_id = pkt[-8:-4]
+        mic = pkt[-4:]
+        # nonce: mac [6], uuid16 [2], count_id [4] # 6+2+4 = 12 bytes
+        nonce = b"".join([mac, uuid, count_id])
+        return decrypt_payload(encrypted_data, mic, key, nonce)
+    else:
+        print("Error: format packet!")
+    return None
+
+
+# =============================
+# main()
+# =============================
+def main():
+    """Encrypt payload."""
+    print()
+    print("====== Test encode -----------------------------------------")
+    temp = 25.06
+    humi = 50.55
+    print("Temperature:", temp, "Humidity:", humi)
+    print()
+    data = bytes(bytearray.fromhex('2302CA090303BF13'))  # HA BLE data (not encrypted)
+    count_id = bytes(bytearray.fromhex('00112233'))  # count id
+    mac = binascii.unhexlify('5448E68F80A5')  # MAC
+    uuid16 = b"\x1E\x18"
+    bindkey = binascii.unhexlify('231d39c1d7cc1ab1aee224cd096db932')
+    print("MAC:", mac.hex(), "Binkey:", bindkey.hex())
+    nonce = b"".join([mac, uuid16, count_id])  # 6+2+4 = 12 bytes
+    cipher = AES.new(bindkey, AES.MODE_CCM, nonce=nonce, mac_len=4)
+    cipher.update(b"\x11")
+    ciphertext, mic = cipher.encrypt_and_digest(data)
+    print("Data:", data.hex())
+    print("Nonce:", nonce.hex())
+    print("CryptData:", ciphertext.hex(), "Mic:", mic.hex())
+    adstruct = b"".join([uuid16, ciphertext, count_id, mic])
+    print()
+    print("Encrypted data:", adstruct.hex())
+    print()
+    print("====== Test decode -----------------------------------------")
+    decrypt_aes_ccm(bindkey, mac, adstruct)
+
+
+if __name__ == '__main__':
+    main()

--- a/package/bleparser/ha_ble_legacy.py
+++ b/package/bleparser/ha_ble_legacy.py
@@ -1,0 +1,156 @@
+"""Parser for HA BLE (DIY sensors) advertisements"""
+import logging
+import struct
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def to_int(value):
+    """Convert to integer"""
+    return value & 0xFF
+
+
+def unsigned_to_signed(unsigned, size):
+    """Convert unsigned to signed"""
+    if (unsigned & (1 << size - 1)) != 0:
+        unsigned = -1 * ((1 << size - 1) - (unsigned & ((1 << size - 1) - 1)))
+    return unsigned
+
+
+def to_sfloat(value):
+    """Convert sfloat to integer"""
+    if len(value) != 2:
+        _LOGGER.debug("conversion to sfloat failed")
+        return 0
+    else:
+        byte_0 = value[0]
+        byte_1 = value[1]
+
+        mantissa = unsigned_to_signed(to_int(byte_0) + ((to_int(byte_1) & 0x0F) << 8), 12)
+        exponent = unsigned_to_signed(to_int(byte_1) >> 4, 4)
+
+        return mantissa * pow(10, exponent)
+
+
+def parse_ha_ble_legacy(self, service_data_list, source_mac, rssi):
+    """Home Assistant BLE parser"""
+    firmware = "HA BLE"
+    device_type = "HA BLE DIY"
+    ha_ble_mac = source_mac
+    result = {}
+    packet_id = None
+
+    for service_data in service_data_list:
+        if len(service_data) == service_data[0] + 1:
+            meas_type = (service_data[3] << 8) | service_data[2]
+            xobj = service_data[4:]
+            if meas_type == 0x2A4D and len(xobj) == 1:
+                (packet_id,) = struct.Struct("<B").unpack(xobj)
+                result.update({"packet": packet_id})
+            elif meas_type == 0x2A19 and len(xobj) == 1:
+                (batt,) = struct.Struct("<B").unpack(xobj)
+                result.update({"battery": batt})
+            elif meas_type == 0x2A6D and len(xobj) == 4:
+                (press,) = struct.Struct("<I").unpack(xobj)
+                result.update({"pressure": press * 0.001})
+            elif meas_type == 0x2A6E and len(xobj) == 2:
+                (temp,) = struct.Struct("<h").unpack(xobj)
+                result.update({"temperature": temp * 0.01})
+            elif meas_type == 0x2A6F and len(xobj) == 2:
+                (humi,) = struct.Struct("<H").unpack(xobj)
+                result.update({"humidity": humi * 0.01})
+            elif meas_type == 0x2A7B and len(xobj) == 1:
+                (dewp,) = struct.Struct("<b").unpack(xobj)
+                result.update({"dewpoint": dewp})
+            elif meas_type == 0x2A98 and len(xobj) == 3:
+                (flag, weight) = struct.Struct("<bH").unpack(xobj)
+                if flag << 0 == 0:
+                    weight_unit = "kg"
+                    factor = 0.005
+                elif flag << 0 == 1:
+                    weight_unit = "lbs"
+                    factor = 0.01
+                else:
+                    weight_unit = "kg"
+                    factor = 0.005
+                result.update({"weight": weight * factor, "weight unit": weight_unit})
+            elif meas_type == 0X2AE2 and len(xobj) == 1:
+                (value,) = struct.Struct("<B").unpack(xobj)
+                result.update({"binary": bool(value)})
+            elif meas_type == 0X2AEA and len(xobj) == 2:
+                (count,) = struct.Struct("<H").unpack(xobj)
+                if count == 0xFFFF:
+                    count = "unknown"
+                result.update({"count": count})
+            elif meas_type == 0X2AEB and len(xobj) == 3:
+                count = int.from_bytes(xobj, "little")
+                if count == 0xFFFFFF:
+                    count = "unknown"
+                result.update({"count": count})
+            elif meas_type == 0X2AF2 and len(xobj) == 4:
+                (enrg,) = struct.Struct("<I").unpack(xobj)
+                result.update({"energy": enrg * 0.001})
+            elif meas_type == 0X2AFB and len(xobj) == 3:
+                illu = int.from_bytes(xobj, "little")
+                result.update({"illuminance": illu * 0.01})
+            elif meas_type == 0x2B05 and len(xobj) == 3:
+                power = int.from_bytes(xobj, "little")
+                result.update({"power": power * 0.1})
+            elif meas_type == 0x2B18 and len(xobj) == 2:
+                (volt,) = struct.Struct("<H").unpack(xobj)
+                result.update({"voltage": volt / 64})
+            elif meas_type == 0x2BD6 and len(xobj) == 2:
+                pm25 = to_sfloat(xobj)
+                result.update({"pm2.5": pm25})
+            elif meas_type == 0x2BD7 and len(xobj) == 2:
+                pm10 = to_sfloat(xobj)
+                result.update({"pm10": pm10})
+            else:
+                _LOGGER.debug(
+                    "Unknown data received from Home Assistant BLE DIY sensor device: %s",
+                    service_data.hex()
+                )
+
+    if not result:
+        if self.report_unknown == "HA BLE":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Home Assistant BLE DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                service_data_list
+            )
+        return None
+
+    # Check for duplicate messages
+    if packet_id:
+        try:
+            prev_packet = self.lpacket_ids[ha_ble_mac]
+        except KeyError:
+            # start with empty first packet
+            prev_packet = None
+        if prev_packet == packet_id:
+            # only process new messages
+            if self.filter_duplicates is True:
+                return None
+        self.lpacket_ids[ha_ble_mac] = packet_id
+    else:
+        result.update({"packet": "no packet id"})
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and ha_ble_mac not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(ha_ble_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join(f'{i:02X}' for i in ha_ble_mac),
+        "type": device_type,
+        "firmware": firmware,
+        "data": True
+    })
+    return result
+
+
+def to_mac(addr: int):
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/helpers.py
+++ b/package/bleparser/helpers.py
@@ -1,0 +1,17 @@
+"""Helpers for bleparser"""
+from uuid import UUID
+
+
+def to_uuid(uuid: str) -> str:
+    """Return formatted UUID"""
+    return str(UUID(''.join(f'{i:02X}' for i in uuid)))
+
+
+def to_mac(addr: str) -> str:
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)
+
+
+def to_unformatted_mac(addr: int):
+    """Return unformatted MAC address"""
+    return ''.join(f'{i:02X}' for i in addr[:])

--- a/package/bleparser/hhcc.py
+++ b/package/bleparser/hhcc.py
@@ -1,0 +1,82 @@
+"""Parser for HHCC BLE advertisements"""
+import logging
+from struct import unpack
+
+from .const import (
+    CONF_MAC,
+    CONF_TYPE,
+    CONF_PACKET,
+    CONF_FIRMWARE,
+    CONF_DATA,
+    CONF_RSSI,
+    CONF_BATTERY,
+    CONF_CONDUCTIVITY,
+    CONF_ILLUMINANCE,
+    CONF_MOISTURE,
+    CONF_TEMPERATURE,
+)
+from .helpers import (
+    to_mac,
+    to_unformatted_mac,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_hhcc(self, data: str, source_mac: str, rssi: float):
+    """HHCC parser"""
+    if len(data) == 13:
+        device_type = "HHCCJCY10"
+        hhcc_mac = source_mac
+        xvalue_1 = data[4:7]
+        xvalue_2 = data[7:10]
+        xvalue_3 = data[10:13]
+        packet_id = data[4:13].hex()
+        (moist, temp) = unpack(">BH", xvalue_1)
+        (illu,) = unpack(">i", b'\x00' + xvalue_2)
+        (batt, cond) = unpack(">BH", xvalue_3)
+        sensor_data = {
+            CONF_TYPE: device_type,
+            CONF_PACKET: packet_id,
+            CONF_FIRMWARE: "HHCC",
+            CONF_DATA: True,
+            CONF_TEMPERATURE: temp / 10,
+            CONF_MOISTURE: moist,
+            CONF_ILLUMINANCE: illu,
+            CONF_CONDUCTIVITY: cond,
+            CONF_BATTERY: batt,
+            CONF_RSSI: rssi,
+            CONF_MAC: to_unformatted_mac(hhcc_mac),
+        }
+    else:
+        if self.report_unknown == "HHCC":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN HHCC DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+
+    # Check for duplicate messages
+    if packet_id:
+        print("packet_id is", packet_id)
+        try:
+            prev_packet = self.lpacket_ids[hhcc_mac]
+        except KeyError:
+            # start with empty first packet
+            prev_packet = None
+        if prev_packet == packet_id:
+            # only process new messages
+            if self.filter_duplicates is True:
+                return None
+        self.lpacket_ids[hhcc_mac] = packet_id
+    else:
+        packet_id = "no packet id"
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and hhcc_mac not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(hhcc_mac))
+        return None
+
+    return sensor_data

--- a/package/bleparser/inkbird.py
+++ b/package/bleparser/inkbird.py
@@ -14,24 +14,33 @@ def convert_temperature(temp):
     return temperature
 
 
-def parse_inkbird(self, data, source_mac, rssi):
+def parse_inkbird(self, data, complete_local_name, source_mac, rssi):
     """Inkbird parser"""
     msg_length = len(data)
     firmware = "Inkbird"
     result = {"firmware": firmware}
     if msg_length == 11:
-        device_type = "IBS-TH"
         inkbird_mac = source_mac
         xvalue = data[2:10]
         (temp, hum) = unpack("<hH", xvalue[0:4])
         bat = int.from_bytes(xvalue[7:8], 'little')
-        result.update(
-            {
-                "temperature": temp / 100,
-                "humidity": hum / 100,
-                "battery": bat,
-            }
-        )
+        if complete_local_name == "sps":
+            device_type = "IBS-TH"
+            result.update(
+                {
+                    "temperature": temp / 100,
+                    "humidity": hum / 100,
+                    "battery": bat,
+                }
+            )
+        elif complete_local_name == "tps":
+            device_type = "IBS-TH2/P01B"
+            result.update(
+                {
+                    "temperature": temp / 100,
+                    "battery": bat,
+                }
+            )
     elif msg_length == 14:
         device_type = "iBBQ-1"
         inkbird_mac = data[6:12]
@@ -129,5 +138,5 @@ def parse_inkbird(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
-    """Convert MAC address."""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/inode.py
+++ b/package/bleparser/inode.py
@@ -235,4 +235,4 @@ def parse_inode(self, data, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/jinou.py
+++ b/package/bleparser/jinou.py
@@ -50,5 +50,5 @@ def parse_jinou(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
-    """Convert MAC address."""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/kegtron.py
+++ b/package/bleparser/kegtron.py
@@ -98,4 +98,5 @@ def parse_kegtron(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/laica.py
+++ b/package/bleparser/laica.py
@@ -1,0 +1,70 @@
+"""Parser for Laica Smart Scale BLE advertisements"""
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def decrypt_value(arr):
+    hex_string = ''
+    for x in arr:
+        hex_string += '%02x' % (x ^ 0xa0)
+    return int(hex_string, 16)
+
+
+def read_weight(data):
+    val = decrypt_value(data[10:14])
+    weight = round((val & 0x3ffff) / 100) / 10
+
+    return weight
+
+
+def read_impedance(data):
+    impedance = decrypt_value(data[10:12])
+    impedance = min(max(impedance, 430), 630)
+
+    return impedance
+
+
+def parse_laica(self, data, source_mac, rssi):
+    xvalue = data[4:]
+
+    result = {
+        "type": "Laica Smart Scale",
+        "firmware": "Laica",
+        "mac": ''.join('{:02X}'.format(x) for x in source_mac),
+        "rssi": rssi,
+        "data": False,
+    }
+
+    if data[14] == 0x06:
+        impedance = read_impedance(data)
+        result.update({
+            "impedance": impedance,
+            "data": True,
+        })
+    elif data[14] == 0x0D:
+        weight = read_weight(data)
+        result.update({
+            "weight": weight,
+            "data": True,
+        })
+
+
+    # Check for duplicate messages
+    packet_id = xvalue.hex()
+    try:
+        prev_packet = self.lpacket_ids[source_mac]
+    except KeyError:
+        # start with empty first packet
+        prev_packet = None
+    if prev_packet == packet_id:
+        # only process new messages
+        if self.filter_duplicates is True:
+            return None
+    self.lpacket_ids[source_mac] = packet_id
+
+    result.update({
+        "packet": packet_id,
+    })
+
+    return result

--- a/package/bleparser/miscale.py
+++ b/package/bleparser/miscale.py
@@ -72,11 +72,17 @@ def parse_miscale(self, data, source_mac, rssi):
         "stabilized": 0 if is_stabilized == 0 else 1
     }
 
-    if is_stabilized and not weight_removed:
-        result.update({"weight": weight})
-
-    if has_impedance:
-        result.update({"impedance": impedance})
+    if device_type == "Mi Scale V1":
+        if is_stabilized and not weight_removed:
+            result.update({"weight": weight})
+    elif device_type == "Mi Scale V2":
+        if is_stabilized and (weight_removed == 0):
+            result.update({"stabilized weight": weight})
+            if has_impedance:
+                result.update({"weight": weight})
+                result.update({"impedance": impedance})
+    else:
+        pass
 
     firmware = device_type
     miscale_mac = source_mac

--- a/package/bleparser/moat.py
+++ b/package/bleparser/moat.py
@@ -64,4 +64,4 @@ def parse_moat(self, data, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/oral_b.py
+++ b/package/bleparser/oral_b.py
@@ -1,4 +1,4 @@
-"""Parser for Oral-B BLE advertisements."""
+"""Parser for Moat BLE advertisements."""
 import logging
 from struct import unpack
 
@@ -48,19 +48,22 @@ def parse_oral_b(self, data, source_mac, rssi):
         else:
             result.update({"toothbrush": 0})
 
+        tb_state = STATES.get(state, "unknown state " + str(state))
+        tb_mode = MODES.get(mode, "unknown mode " + str(mode))
+
         if sector == 254:
-            sector = "last sector"
+            tb_sector = "last sector"
         elif sector == 255:
-            sector = "no sector"
+            tb_sector = "no sector"
         else:
-            sector = "sector " + str(sector)
+            tb_sector = "sector " + str(sector)
 
         result.update({
-            "toothbrush state": STATES[state],
+            "toothbrush state": tb_state,
             "pressure": pressure,
             "counter": counter,
-            "mode": MODES[mode],
-            "sector": sector,
+            "mode": tb_mode,
+            "sector": tb_sector,
             "sector timer": sector_timer,
             "number of sectors": no_of_sectors,
         })
@@ -82,7 +85,7 @@ def parse_oral_b(self, data, source_mac, rssi):
 
     result.update({
         "rssi": rssi,
-        "mac": ''.join('{:02X}'.format(x) for x in oral_b_mac[:]),
+        "mac": ''.join(f'{i:02X}' for i in oral_b_mac),
         "type": device_type,
         "packet": "no packet id",
         "firmware": firmware,
@@ -93,4 +96,4 @@ def parse_oral_b(self, data, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/qingping.py
+++ b/package/bleparser/qingping.py
@@ -115,4 +115,4 @@ def parse_qingping(self, data, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/relsib.py
+++ b/package/bleparser/relsib.py
@@ -1,0 +1,74 @@
+"""Parser for Relsib EClerk-Eco-RHTC BLE advertisements"""
+import logging
+from struct import unpack
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_relsib(self, data, source_mac, rssi):
+    """Relsib parser"""
+    msg_length = len(data)
+    if msg_length == 26:
+        firmware = "Relsib (EClerk Eco v9a)"
+        device_type = "EClerk Eco"
+        relsib_mac = source_mac
+
+        result = {
+            "rssi": rssi,
+            "packet": "no packet id",
+        }
+        if data[2] == 0x20:
+            xdata_point = 8
+        else:
+            xdata_point = 4
+
+        # Device is sending placeholder when sensor is not ready
+        nan = 0x8000
+
+        (temp, humi, co2) = unpack("<HHH", data[xdata_point:xdata_point + 6])
+        if temp != nan:
+            result.update({"temperature": temp / 100})
+        if humi != nan:
+            result.update({"humidity": humi / 100})
+        if co2 != nan:
+            result.update({"co2": co2})
+
+        if data[2] == 0x20:
+            # Only 0xAA20 packet has battery info
+            battery = data[17]
+            # First bit means power adapter plugged in
+            if battery & 0b10000000:
+                result.update({"battery": 100})
+            else:
+                result.update({"battery": battery & 0b01111111})
+
+    else:
+        device_type = None
+    if device_type is None:
+        if self.report_unknown == "Relsib":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Relsib DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and relsib_mac not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(relsib_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join('{:02X}'.format(x) for x in relsib_mac[:]),
+        "type": device_type,
+        "firmware": firmware,
+        "data": True
+    })
+    return result
+
+
+def to_mac(addr: int):
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/ruuvitag.py
+++ b/package/bleparser/ruuvitag.py
@@ -206,4 +206,5 @@ def parse_ruuvitag(self, data, source_mac, rssi):
 
 
 def to_mac(addr: int):
-    return ":".join("{:02x}".format(x) for x in addr).upper()
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/sensirion.py
+++ b/package/bleparser/sensirion.py
@@ -1,7 +1,14 @@
-# Parser for Sensirion BLE advertisements
+"""Parser for Sensirion BLE advertisements"""
 import logging
 
 _LOGGER = logging.getLogger(__name__)
+
+SENSIRION_DEVICES = [
+    "MyCO2",
+    "SHT40 Gadget",
+    "SHT41 Gadget",
+    "SHT45 Gadget",
+]
 
 
 def parse_sensirion(self, data, complete_local_name, source_mac, rssi):
@@ -10,7 +17,7 @@ def parse_sensirion(self, data, complete_local_name, source_mac, rssi):
     sensirion_mac = source_mac
     device_type = complete_local_name
 
-    if device_type != "MyCO2":
+    if device_type not in SENSIRION_DEVICES:
         if self.report_unknown == "Sensirion":
             _LOGGER.info(
                 "BLE ADV from UNKNOWN Sensirion DEVICE: RSSI: %s, MAC: %s, ADV: %s",
@@ -29,22 +36,21 @@ def parse_sensirion(self, data, complete_local_name, source_mac, rssi):
     # not all of the following values are used yet, but this explains the full protocol
     # bytes 1+2 (length and type) are part of the header
     advertisementLength = data[0]  # redundant
-    advertisementType0 = data[1]   # redundant (also encoded in body - see below)
+    advertisementType0 = data[1]  # redundant (also encoded in body - see below)
     companyId = data[2:3]  # redundant (already part of the metadata)
     advertisementType = int(data[4])
     advSampleType = int(data[5])
     deviceName = f'{data[6]:x}:{data[7]:x}'  # as shown in Sensirion MyAmbience app (last 4 bytes of MAC address)
 
-    if(advertisementType == 0):
+    if advertisementType == 0:
         samples = _parse_dataType(advSampleType, data[8:])
-
         if not samples:
             return None
         else:
             result.update(samples)
             result.update({
                 "rssi": rssi,
-                "mac": to_mac(source_mac),
+                "mac": ''.join('{:02X}'.format(x) for x in sensirion_mac[:]),
                 "type": device_type,
                 "packet": "no packet id",
                 "data": True
@@ -58,7 +64,7 @@ def parse_sensirion(self, data, complete_local_name, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)
 
 
 '''
@@ -68,7 +74,10 @@ support from other devices should be easily added by looking at GadgetBle::setDa
 
 
 def _parse_dataType(advSampleType, byte_data):
-    if(advSampleType == 8):
+    if (advSampleType == 6):
+        return {'temperature': _decodeTemperatureV1(byte_data[0:2]),
+                'humidity': _decodeHumidityV1(byte_data[2:4])}
+    elif (advSampleType == 8):
         return {'temperature': _decodeTemperatureV1(byte_data[0:2]),
                 'humidity': _decodeHumidityV1(byte_data[2:4]),
                 'co2': _decodeSimple(byte_data[4:6])}

--- a/package/bleparser/sensorpush.py
+++ b/package/bleparser/sensorpush.py
@@ -103,4 +103,4 @@ def parse_sensorpush(self, data, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/switchbot.py
+++ b/package/bleparser/switchbot.py
@@ -1,0 +1,63 @@
+"""Parser for Switchbot BLE advertisements"""
+import logging
+from struct import unpack
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_switchbot(self, data, source_mac, rssi):
+    """Switchbot parser"""
+    msg_length = len(data)
+    switchbot_mac = source_mac
+    device_id = data[4] + (data[5] << 8)
+
+    if msg_length == 10 and device_id in [0x0054, 0x0069]:
+        xvalue = data[6:10]
+        (byte1, byte2, byte3, byte4) = unpack("<BBBB", xvalue)
+        batt = (byte1 & 127)
+        temp = float(byte3 - 128) + float(byte2 / 10.0)
+        humi = (byte4 & 127)
+        if device_id == 0x0054:
+            device_type = "Meter TH S1"
+        elif device_id == 0x0069:
+            device_type = "Meter TH plus"
+        else:
+            device_type = "unknown"
+        firmware = "Switchbot"
+        result = {
+            "temperature": temp,
+            "humidity": humi,
+            "battery": batt
+        }
+    else:
+        device_type = "unknown"
+
+    if device_type == "unknown":
+        if self.report_unknown == "Switchbot":
+            _LOGGER.info(
+                "BLE ADV from UNKNOWN Switchbot DEVICE: RSSI: %s, MAC: %s, ADV: %s",
+                rssi,
+                to_mac(source_mac),
+                data.hex()
+            )
+        return None
+
+    # check for MAC presence in sensor whitelist, if needed
+    if self.discovery is False and switchbot_mac not in self.sensor_whitelist:
+        _LOGGER.debug("Discovery is disabled. MAC: %s is not whitelisted!", to_mac(switchbot_mac))
+        return None
+
+    result.update({
+        "rssi": rssi,
+        "mac": ''.join(f'{i:02X}' for i in switchbot_mac),
+        "type": device_type,
+        "packet": "no packet id",
+        "firmware": firmware,
+        "data": True
+    })
+    return result
+
+
+def to_mac(addr: int):
+    """Return formatted MAC address"""
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/teltonika.py
+++ b/package/bleparser/teltonika.py
@@ -18,6 +18,8 @@ def parse_teltonika(self, data, complete_local_name, source_mac, rssi):
         device_type = "Blue Coin T"
     elif complete_local_name[0:3] == "P T":
         device_type = "Blue Puck T"
+    elif complete_local_name[0:5] == "P RHT":
+        device_type = "Blue Puck RHT"
     else:
         device_type = None
 
@@ -70,4 +72,4 @@ def parse_teltonika(self, data, complete_local_name, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/thermoplus.py
+++ b/package/bleparser/thermoplus.py
@@ -75,4 +75,4 @@ def parse_thermoplus(self, data, source_mac, rssi):
 
 def to_mac(addr: int):
     """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()
+    return ':'.join(f'{i:02X}' for i in addr)

--- a/package/bleparser/xiaogui.py
+++ b/package/bleparser/xiaogui.py
@@ -1,6 +1,10 @@
 """Parser for Xiaogui Scale BLE advertisements"""
 import logging
 from struct import unpack
+from .helpers import (
+    to_mac,
+    to_unformatted_mac,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -11,7 +15,6 @@ def parse_xiaogui(self, data, source_mac, rssi):
 
     if msg_length == 17:
         firmware = "Xiaogui"
-        device_type = "TZC4"
         xiaogui_mac = data[11:]
 
         if xiaogui_mac != source_mac:
@@ -20,8 +23,7 @@ def parse_xiaogui(self, data, source_mac, rssi):
 
         result = {
             "firmware": firmware,
-            "type": device_type,
-            "mac": ''.join('{:02X}'.format(x) for x in xiaogui_mac),
+            "mac": to_unformatted_mac(xiaogui_mac),
             "rssi": rssi,
             "data": True,
         }
@@ -33,12 +35,26 @@ def parse_xiaogui(self, data, source_mac, rssi):
         result.update({"packet": packet_id})
 
         if stablilized_byte == 0x20:
+            device_type = "TZC4"
             result.update({"non-stabilized weight": weight / 10})
             result.update({"weight unit": "kg"})
             result.update({"stabilized": 0})
         elif stablilized_byte == 0x21:
+            device_type = "TZC4"
             result.update({"non-stabilized weight": weight / 10})
             result.update({"weight": weight / 10})
+            result.update({"weight unit": "kg"})
+            result.update({"impedance": impedance / 10})
+            result.update({"stabilized": 1})
+        elif stablilized_byte == 0x24:
+            device_type = "QJ-J"
+            result.update({"non-stabilized weight": weight / 100})
+            result.update({"weight unit": "kg"})
+            result.update({"stabilized": 0})
+        elif stablilized_byte == 0x25:
+            device_type = "QJ-J"
+            result.update({"non-stabilized weight": weight / 100})
+            result.update({"weight": weight / 100})
             result.update({"weight unit": "kg"})
             result.update({"impedance": impedance / 10})
             result.update({"stabilized": 1})
@@ -48,9 +64,10 @@ def parse_xiaogui(self, data, source_mac, rssi):
                 "please report an issue to the developers with this error: Payload is %s",
                 data.hex()
             )
-            result.update({"data": False})
+            device_type = None
     else:
         device_type = None
+
     if device_type is None:
         if self.report_unknown == "Xiaogui":
             _LOGGER.info(
@@ -59,6 +76,8 @@ def parse_xiaogui(self, data, source_mac, rssi):
                 data.hex()
             )
         return None
+    else:
+        result.update({"type": device_type})
 
     # Check for duplicate messages
     try:
@@ -77,8 +96,3 @@ def parse_xiaogui(self, data, source_mac, rssi):
         return None
 
     return result
-
-
-def to_mac(addr: int):
-    """Return formatted MAC address"""
-    return ':'.join('{:02x}'.format(x) for x in addr).upper()

--- a/package/bleparser/xiaomi.py
+++ b/package/bleparser/xiaomi.py
@@ -1,10 +1,10 @@
-# Parser for Xiaomi MiBeacon BLE advertisements
+"""Parser for Xiaomi MiBeacon BLE advertisements"""
 import logging
 import math
 import struct
 from Cryptodome.Cipher import AES
 
-from datetime import datetime
+from homeassistant.util import datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -98,16 +98,16 @@ BLE_LOCK_ERROR = {
 }
 
 BLE_LOCK_ACTION = {
-    0b0000: [0, "unlock outside the door"],
-    0b0001: [1, "lock"],
-    0b0010: [1, "turn on anti-lock"],
-    0b0011: [0, "turn off anti-lock"],
-    0b0100: [0, "unlock inside the door"],
-    0b0101: [1, "lock inside the door"],
-    0b0110: [1, "turn on child lock"],
-    0b0111: [0, "turn off child lock"],
-    0b1000: [1, "lock outside the door"],
-    0b1111: [0, "abnormal"],
+    0b0000: [1, "lock", "unlock outside the door"],
+    0b0001: [0, "lock", "lock"],
+    0b0010: [0, "antilock", "turn on anti-lock"],
+    0b0011: [1, "antilock", "turn off anti-lock"],
+    0b0100: [1, "lock", "unlock inside the door"],
+    0b0101: [0, "lock", "lock inside the door"],
+    0b0110: [0, "childlock", "turn on child lock"],
+    0b0111: [1, "childlock", "turn off child lock"],
+    0b1000: [0, "lock", "lock outside the door"],
+    0b1111: [1, "lock", "abnormal"],
 }
 
 BLE_LOCK_METHOD = {
@@ -130,12 +130,12 @@ BLE_LOCK_METHOD = {
 # Advertisement conversion of measurement data
 # https://iot.mi.com/new/doc/embedded-development/ble/object-definition
 def obj0003(xobj):
-    # Motion
+    """Motion"""
     return {"motion": xobj[0], "motion timer": xobj[0]}
 
 
 def obj0006(xobj):
-    # Fingerprint
+    """Fingerprint"""
     if len(xobj) == 5:
         key_id = xobj[0:4]
         match_byte = xobj[4]
@@ -173,16 +173,42 @@ def obj0006(xobj):
         return {}
 
 
+def obj0007(xobj):
+    """Door"""
+    door_byte = xobj[0]
+    if door_byte == 0x00:
+        action = "open the door"
+        door = 1
+    elif door_byte == 0x01:
+        action = "close the door"
+        door = 0
+    elif door_byte == 0x02:
+        action = "timeout, not closed"
+        door = 1
+    elif door_byte == 0x03:
+        action = "knock on the door"
+        door = 0
+    elif door_byte == 0x04:
+        action = "pry the door"
+        door = 1
+    elif door_byte == 0x05:
+        action = "door stuck"
+        door = 0
+    else:
+        return {}
+    return {"door": door, "door action": action}
+
+
 def obj0010(xobj):
-    # Toothbrush
+    """Toothbrush"""
     if xobj[0] == 0:
         return {'toothbrush': 1, 'counter': xobj[1]}
     else:
         return {'toothbrush': 0, 'score': xobj[1]}
 
 
-def obj000b(xobj):
-    # Lock
+def obj000b(xobj, device_type):
+    """Lock"""
     if len(xobj) == 9:
         action = xobj[0] & 0x0F
         method = xobj[0] >> 4
@@ -202,11 +228,16 @@ def obj000b(xobj):
             return {}
 
         lock = BLE_LOCK_ACTION[action][0]
-        action = BLE_LOCK_ACTION[action][1]
+        # Decouple lock by type on some devices
+        lock_type = "lock"
+        if device_type == "ZNMS17LM":
+            lock_type = BLE_LOCK_ACTION[action][1]
+        action = BLE_LOCK_ACTION[action][2]
         method = BLE_LOCK_METHOD[method]
 
         return {
-            "lock": lock,
+            lock_type: lock,
+            "locktype": lock_type,
             "action": action,
             "method": method,
             "error": error,
@@ -218,7 +249,7 @@ def obj000b(xobj):
 
 
 def obj000f(xobj, device_type):
-    # Moving with light
+    """Moving with light"""
     if len(xobj) == 3:
         (value,) = LIGHT_STRUCT.unpack(xobj + b'\x00')
 
@@ -236,6 +267,7 @@ def obj000f(xobj, device_type):
 
 
 def obj1001(xobj, device_type):
+    """button"""
     if len(xobj) == 3:
         (button_type, value, press) = BUTTON_STRUCT.unpack(xobj)
 
@@ -250,6 +282,7 @@ def obj1001(xobj, device_type):
         three_btn_switch_left = None
         three_btn_switch_middle = None
         three_btn_switch_right = None
+        cube_direction = None
         remote_binary = None
 
         if button_type == 0:
@@ -260,6 +293,7 @@ def obj1001(xobj, device_type):
             one_btn_switch = "toggle"
             two_btn_switch_left = "toggle"
             three_btn_switch_left = "toggle"
+            cube_direction = "right"
             remote_binary = 1
         elif button_type == 1:
             remote_command = "off"
@@ -268,6 +302,7 @@ def obj1001(xobj, device_type):
             bathroom_remote_command = "air exchange"
             two_btn_switch_right = "toggle"
             three_btn_switch_middle = "toggle"
+            cube_direction = "left"
             remote_binary = 0
         elif button_type == 2:
             remote_command = "sun"
@@ -315,17 +350,14 @@ def obj1001(xobj, device_type):
         # press type and dimmer
         button_press_type = "no press"
         btn_switch_press_type = "no press"
-        cube_direction = None
         dimmer = None
 
         if press == 0:
             button_press_type = "single press"
             btn_switch_press_type = "single press"
-            cube_direction = "right"
         elif press == 1:
             button_press_type = "double press"
             btn_switch_press_type = "long press"
-            cube_direction = "left"
         elif press == 2:
             button_press_type = "long press"
             btn_switch_press_type = "double press"
@@ -407,7 +439,7 @@ def obj1001(xobj, device_type):
 
 
 def obj1004(xobj):
-    # Temperature
+    """Temperature"""
     if len(xobj) == 2:
         (temp,) = T_STRUCT.unpack(xobj)
         return {"temperature": temp / 10}
@@ -416,11 +448,12 @@ def obj1004(xobj):
 
 
 def obj1005(xobj):
+    """Switch and Temperature"""
     return {"switch": xobj[0], "temperature": xobj[1]}
 
 
 def obj1006(xobj):
-    # Humidity
+    """Humidity"""
     if len(xobj) == 2:
         (humi,) = H_STRUCT.unpack(xobj)
         return {"humidity": humi / 10}
@@ -429,7 +462,7 @@ def obj1006(xobj):
 
 
 def obj1007(xobj):
-    # Illuminance
+    """Illuminance"""
     if len(xobj) == 3:
         (illum,) = ILL_STRUCT.unpack(xobj + b'\x00')
         return {"illuminance": illum, "light": 1 if illum == 100 else 0}
@@ -438,12 +471,12 @@ def obj1007(xobj):
 
 
 def obj1008(xobj):
-    # Moisture
+    """Moisture"""
     return {"moisture": xobj[0]}
 
 
 def obj1009(xobj):
-    # Conductivity
+    """Conductivity"""
     if len(xobj) == 2:
         (cond,) = CND_STRUCT.unpack(xobj)
         return {"conductivity": cond}
@@ -452,7 +485,7 @@ def obj1009(xobj):
 
 
 def obj1010(xobj):
-    # Formaldehyde
+    """Formaldehyde"""
     if len(xobj) == 2:
         (fmdh,) = FMDH_STRUCT.unpack(xobj)
         return {"formaldehyde": fmdh / 100}
@@ -461,27 +494,27 @@ def obj1010(xobj):
 
 
 def obj1012(xobj):
-    # Switch
+    """Switch"""
     return {"switch": xobj[0]}
 
 
 def obj1013(xobj):
-    # Consumable (in percent)
+    """Consumable (in percent)"""
     return {"consumable": xobj[0]}
 
 
 def obj1014(xobj):
-    # Moisture
+    """Moisture"""
     return {"moisture": xobj[0]}
 
 
 def obj1015(xobj):
-    # Smoke
+    """Smoke"""
     return {"smoke detector": xobj[0]}
 
 
 def obj1017(xobj):
-    # Motion
+    """Motion"""
     if len(xobj) == 4:
         (motion,) = M_STRUCT.unpack(xobj)
         # seconds since last motion detected message (not used, we use motion timer in obj000f)
@@ -492,12 +525,12 @@ def obj1017(xobj):
 
 
 def obj1018(xobj):
-    # Light intensity
+    """Light intensity"""
     return {"light": xobj[0]}
 
 
 def obj1019(xobj):
-    # Door
+    """Door/Window sensor"""
     open_obj = xobj[0]
     if open_obj == 0:
         opening = 1
@@ -518,14 +551,14 @@ def obj1019(xobj):
 
 
 def obj100a(xobj):
-    # Battery
+    """Battery"""
     batt = xobj[0]
     volt = 2.2 + (3.1 - 2.2) * (batt / 100)
     return {"battery": batt, "voltage": volt}
 
 
 def obj100d(xobj):
-    # Temperature and humidity
+    """Temperature and humidity"""
     if len(xobj) == 4:
         (temp, humi) = TH_STRUCT.unpack(xobj)
         return {"temperature": temp / 10, "humidity": humi / 10}
@@ -534,7 +567,7 @@ def obj100d(xobj):
 
 
 def obj2000(xobj):
-    # Body temperature
+    """Body temperature"""
     if len(xobj) == 5:
         (temp1, temp2, bat) = TTB_STRUCT.unpack(xobj)
         # Body temperature is calculated from the two measured temperatures.
@@ -552,12 +585,13 @@ def obj2000(xobj):
 # The following data objects are device specific. For now only added for XMWSDJ04MMC
 # https://miot-spec.org/miot-spec-v2/instances?status=all
 def obj4803(xobj):
-    # Battery
+    """Battery"""
     batt = xobj[0]
     return {"battery": batt}
 
 
 def obj4c01(xobj):
+    """Temperature"""
     if len(xobj) == 4:
         temp = FLOAT_STRUCT.unpack(xobj)[0]
         return {"temperature": temp}
@@ -566,6 +600,7 @@ def obj4c01(xobj):
 
 
 def obj4c08(xobj):
+    """Humidity"""
     if len(xobj) == 4:
         humi = FLOAT_STRUCT.unpack(xobj)[0]
         return {"humidity": humi}
@@ -578,6 +613,7 @@ def obj4c08(xobj):
 xiaomi_dataobject_dict = {
     0x0003: obj0003,
     0x0006: obj0006,
+    0x0007: obj0007,
     0x0010: obj0010,
     0x000B: obj000b,
     0x000F: obj000f,
@@ -606,6 +642,7 @@ xiaomi_dataobject_dict = {
 
 
 def parse_xiaomi(self, data, source_mac, rssi):
+    """Parser for Xiaomi sensors"""
     # check for adstruc length
     i = 9  # till Frame Counter
     msg_length = len(data)
@@ -697,7 +734,7 @@ def parse_xiaomi(self, data, source_mac, rssi):
         # start with empty first packet
         prev_packet = None
 
-    if device_type in ["LYWSD03MMC", "CGG1", "MHO-C401"]:
+    if device_type in ["LYWSD03MMC", "CGG1", "MHO-C401", "CGDK2"]:
         # Check for adv priority and packet_id for devices that can also send in ATC format
         adv_priority = 19
         try:
@@ -791,14 +828,14 @@ def parse_xiaomi(self, data, source_mac, rssi):
             if payload_length < next_start:
                 _LOGGER.debug("Invalid payload data length, payload: %s", payload.hex())
                 break
-            dobject  = payload[payload_start + 3:next_start]
+            dobject = payload[payload_start + 3:next_start]
             if obj_length != 0:
                 resfunc = xiaomi_dataobject_dict.get(obj_typecode, None)
                 if resfunc:
-                    if hex(obj_typecode) in ["0x1001", "0xf"]:
-                        result.update(resfunc(dobject , device_type))
+                    if hex(obj_typecode) in ["0x1001", "0xf", "0xb"]:
+                        result.update(resfunc(dobject, device_type))
                     else:
-                        result.update(resfunc(dobject ))
+                        result.update(resfunc(dobject))
                 else:
                     if self.report_unknown == "Xiaomi":
                         _LOGGER.info("%s, UNKNOWN dataobject in payload! Adv: %s", sinfo, data.hex())
@@ -808,6 +845,7 @@ def parse_xiaomi(self, data, source_mac, rssi):
 
 
 def decrypt_mibeacon_v4_v5(self, data, i, xiaomi_mac):
+    """decrypt MiBeacon v4/v5 encrypted advertisements"""
     # check for minimum length of encrypted advertisement
     if len(data) < i + 9:
         _LOGGER.debug("Invalid data length (for decryption), adv: %s", data.hex())
@@ -847,6 +885,7 @@ def decrypt_mibeacon_v4_v5(self, data, i, xiaomi_mac):
 
 
 def decrypt_mibeacon_legacy(self, data, i, xiaomi_mac):
+    """decrypt MiBeacon v2/v3 encrypted advertisements"""
     # check for minimum length of encrypted advertisement
     if len(data) < i + 7:
         _LOGGER.debug("Invalid data length (for decryption), adv: %s", data.hex())

--- a/package/bleparser/xiaomi.py
+++ b/package/bleparser/xiaomi.py
@@ -4,7 +4,7 @@ import math
 import struct
 from Cryptodome.Cipher import AES
 
-from homeassistant.util import datetime
+from datetime import datetime
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/package/tests/test_acconeer.py
+++ b/package/tests/test_acconeer.py
@@ -1,0 +1,25 @@
+"""The tests for the Acconeer ble_parser."""
+from bleparser import BleParser
+
+
+class TestAcconeer:
+    """Tests for the Acconeer parser"""
+    def test_acconeer_xm122(self):
+        """Test acconeer parser for Acconeer XM122."""
+        data_string = "043e22020103013412b69009e01602010612ffc0ac806400160001000000000000000000c2"
+
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Acconeer"
+        assert sensor_msg["type"] == "Acconeer XM122"
+        assert sensor_msg["mac"] == "E00990B61234"
+        assert sensor_msg["packet"] == "6400160001000000000000000000"
+        assert sensor_msg["data"]
+        assert sensor_msg["battery"] == 100
+        assert sensor_msg["temperature"] == 22
+        assert sensor_msg["motion"] == 1
+        assert sensor_msg["rssi"] == -62

--- a/package/tests/test_airmentor.py
+++ b/package/tests/test_airmentor.py
@@ -1,0 +1,44 @@
+"""The tests for the Air Mentor ble_parser."""
+from bleparser import BleParser
+
+
+class TestSwitchbot:
+    """Tests for the Air Mentor parser"""
+    def test_air_mentor_pro_2_set_1(self):
+        """Test Air Mentor parser for Air Mentor Pro 2."""
+        data_string = "043E1B02010000A7808FE648540F0201060BFF222100b91963332d0145CC"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Air Mentor"
+        assert sensor_msg["type"] == "Air Mentor Pro 2"
+        assert sensor_msg["mac"] == "5448E68F80A7"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 24.99
+        assert sensor_msg["temperature calibrated"] == 19.89
+        assert sensor_msg["humidity"] == 61.34
+        assert sensor_msg["tvoc"] == 185
+        assert sensor_msg["aqi"] == 325
+        assert sensor_msg["air quality"] == "hazardous"
+        assert sensor_msg["rssi"] == -52
+
+    def test_air_mentor_pro_2_set_2(self):
+        """Test Air Mentor parser for Air Mentor Pro 2."""
+        data_string = "043E1B02010000A7808FE648540F0201060BFF21212710000300030000CC"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Air Mentor"
+        assert sensor_msg["type"] == "Air Mentor Pro 2"
+        assert sensor_msg["mac"] == "5448E68F80A7"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["co2"] == 10000
+        assert sensor_msg["pm2.5"] == 3
+        assert sensor_msg["pm10"] == 3
+        assert sensor_msg["rssi"] == -52

--- a/package/tests/test_altbeacon_parser.py
+++ b/package/tests/test_altbeacon_parser.py
@@ -1,6 +1,8 @@
-'''The tests for the AltBeacon ble_parser.'''
-from bleparser import BleParser
+"""The tests for the AltBeacon ble_parser."""
 from uuid import UUID
+
+from bleparser import BleParser
+
 
 class TestAltBeacon:
     '''Tests for the AltBeacon parser'''
@@ -18,7 +20,7 @@ class TestAltBeacon:
         assert sensor_msg['firmware'] == 'AltBeacon'
         assert sensor_msg['manufacturer'] == 'Other'
         assert sensor_msg['rssi'] == -44
-        assert sensor_msg['mac'] == '6D:40:27:85:98:05'
+        assert sensor_msg['mac'] == '6D4027859805'
         assert str(UUID(sensor_msg['uuid'])) == 'd3162f5a-f3ee-4947-99db-09756062d0fc'
         assert sensor_msg['uuid'] == 'd3162f5af3ee494799db09756062d0fc'
         assert sensor_msg['major'] == 90
@@ -39,11 +41,11 @@ class TestAltBeacon:
         assert sensor_msg['firmware'] == 'AltBeacon'
         assert sensor_msg['manufacturer'] == 'Other'
         assert sensor_msg['rssi'] == -44
-        assert sensor_msg['mac'] == '6D:40:27:85:98:05'
+        assert sensor_msg['mac'] == '6D4027859805'
         assert str(UUID(sensor_msg['uuid'])) == 'd3162f5a-f3ee-4947-99db-09756062d0fc'
         assert sensor_msg['uuid'] == 'd3162f5af3ee494799db09756062d0fc'
         assert sensor_msg['major'] == 90
         assert sensor_msg['minor'] == 5
         assert sensor_msg['measured power'] == -60
         assert tracker_msg['tracker_id'] == b'\xd3\x16/Z\xf3\xeeIG\x99\xdb\tu`b\xd0\xfc'
-        assert sensor_msg is not None 
+        assert sensor_msg is not None

--- a/package/tests/test_govee_parser.py
+++ b/package/tests/test_govee_parser.py
@@ -13,7 +13,7 @@ class TestGovee:
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
-        assert sensor_msg["type"] == "H5051"
+        assert sensor_msg["type"] == "H5051/H5071"
         assert sensor_msg["mac"] == "E3605961BBAA"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]

--- a/package/tests/test_ha_ble.py
+++ b/package/tests/test_ha_ble.py
@@ -1,0 +1,271 @@
+"""The tests for the HA BLE (DIY sensor) ble_parser."""
+from bleparser import BleParser
+
+
+class TestHaBle:
+    """Tests for the HA BLE (DIY sensor) parser"""
+    def test_ha_ble_packet_and_battery(self):
+        """Test HA BLE parser for battery measurement and packet number"""
+        data_string = "043E1902010000A5808FE648540D02010609161C18020009020161CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == 9
+        assert sensor_msg["data"]
+        assert sensor_msg["battery"] == 97
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_temperature_and_humidity(self):
+        """Test HA BLE parser for temperature and humidity measurement"""
+        data_string = "043E1B02010000A5808FE648540F0201060B161C182302CA090303BF13CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 25.06
+        assert sensor_msg["humidity"] == 50.55
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_temperature_and_humidity_encrypted(self):
+        """Test HA BLE parser for temperature and humidity (encrypted) measurement"""
+        self.aeskeys = {}
+        data_string = "043E2302010000A5808FE648541702010613161e18fba435e4d3c312fb0011223357d90a99CC"
+        data = bytes(bytearray.fromhex(data_string))
+        aeskey = "231d39c1d7cc1ab1aee224cd096db932"
+
+        p_mac = bytes.fromhex("5448E68F80A5")
+        p_key = bytes.fromhex(aeskey.lower())
+        self.aeskeys[p_mac] = p_key
+        allow_list = self.aeskeys.keys()
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser(aeskeys=self.aeskeys, discovery=False, sensor_whitelist=allow_list)
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE (encrypted)"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == 857870592
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 25.06
+        assert sensor_msg["humidity"] == 50.55
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_pressure(self):
+        """Test HA BLE parser for pressure measurement"""
+        data_string = "043E1B02010000A5808FE648540F0201060B161C1802000C0404138A01DC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == 12
+        assert sensor_msg["data"]
+        assert sensor_msg["pressure"] == 1008.83
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_illuminance(self):
+        """Test HA BLE parser for illuminance measurement"""
+        data_string = "043E1802010000A5808FE648540C02010608161C180405138A14DC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["illuminance"] == 13460.67
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_weight(self):
+        """Test HA BLE parser for weight measurement"""
+        data_string = "043E1B02010000A5808FE648540F0201060B161C1803065E1F63076B67DC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["weight"] == 80.3
+        assert sensor_msg["weight unit"] == "kg"
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_dewpoint(self):
+        """Test HA BLE parser for dewpoint measurement"""
+        data_string = "043E1702010000A5808FE648540B02010607161C182308CA06DC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["dewpoint"] == 17.38
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_energy(self):
+        """Test HA BLE parser for energy measurement"""
+        data_string = "043E1802010000A5808FE648540C02010608161C18040A138A14DC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["energy"] == 1346.067
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_power(self):
+        """Test HA BLE parser for power measurement"""
+        data_string = "043E1802010000A5808FE648540C02010608161C18040B021B00DC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["power"] == 69.14
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_voltage(self):
+        """Test HA BLE parser for voltage measurement"""
+        data_string = "043E1702010000A5808FE648540B02010607161C18030C020CDC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["voltage"] == 3.074
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_pm(self):
+        """Test HA BLE parser for PM2.5 and PM10 measurement"""
+        data_string = "043E1B02010000A5808FE648540F0201060B161C18030D120C030E021CDC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["pm2.5"] == 3090
+        assert sensor_msg["pm10"] == 7170
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_binary(self):
+        """Test HA BLE parser for binary sensor measurement"""
+        data_string = "043E1602010000A5808FE648540A02010606161C18020F01CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["binary"] == 1
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_switch(self):
+        """Test HA BLE parser for dew point measurement"""
+        data_string = "043E1602010000A5808FE648540A02010606161C18021001DC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["switch"] == 1
+        assert sensor_msg["rssi"] == -36
+
+    def test_ha_ble_opening(self):
+        """Test HA BLE parser for opening measurement"""
+        data_string = "043E1602010000A5808FE648540A02010606161C18021100CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A5"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["opening"] == 0
+        assert sensor_msg["rssi"] == -52
+
+    def test_ha_ble_modified_mac(self):
+        """Test HA BLE parser for binary sensor with modified MAC"""
+        data_string = "043E1D02010000A5808FE64854110201060D161C18020F0186A6808FE64854CC"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HA BLE"
+        assert sensor_msg["type"] == "HA BLE DIY"
+        assert sensor_msg["mac"] == "5448E68F80A6"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["binary"] == 1
+        assert sensor_msg["rssi"] == -52

--- a/package/tests/test_hhcc.py
+++ b/package/tests/test_hhcc.py
@@ -1,0 +1,26 @@
+"""The tests for the HHCC ble_parser."""
+from bleparser import BleParser
+
+
+class TestHHCC:
+    """Tests for the HHCC parser"""
+    def test_hhcc_HHCCJCY10(self):
+        """Test HHCC BLE parser for HHCCJCY10"""
+        data_string = "043e2002010001c211e44d23dc14020106030250fd0c1650fd0e006e0134a428005bae"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "HHCC"
+        assert sensor_msg["type"] == "HHCCJCY10"
+        assert sensor_msg["mac"] == "DC234DE411C2"
+        assert sensor_msg["packet"] == "0e006e0134a428005b"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 11.0
+        assert sensor_msg["moisture"] == 14
+        assert sensor_msg["illuminance"] == 79012
+        assert sensor_msg["conductivity"] == 91
+        assert sensor_msg["battery"] == 40
+        assert sensor_msg["rssi"] == -82

--- a/package/tests/test_ibeacon_parser.py
+++ b/package/tests/test_ibeacon_parser.py
@@ -1,6 +1,8 @@
-'''The tests for the iBeacon ble_parser.'''
-from bleparser import BleParser
+"""The tests for the iBeacon ble_parser."""
 from uuid import UUID
+
+from bleparser import BleParser
+
 
 class TestIBeacon:
     '''Tests for the iBeacon parser'''
@@ -17,7 +19,7 @@ class TestIBeacon:
         assert sensor_msg['packet'] == 'no packet id'
         assert sensor_msg['firmware'] == 'iBeacon'
         assert sensor_msg['rssi'] == -77
-        assert sensor_msg['mac'] == '6A:6B:C9:A2:3E:43'
+        assert sensor_msg['mac'] == '6A6BC9A23E43'
         assert str(UUID(sensor_msg['uuid'])) == 'e2c56db5-dffb-48d2-b060-d0f5a71096e0'
         assert sensor_msg['uuid'] == 'e2c56db5dffb48d2b060d0f5a71096e0'
         assert sensor_msg['major'] == 100
@@ -37,7 +39,7 @@ class TestIBeacon:
 
         assert tracker_msg['is connected']
         assert tracker_msg['rssi'] == -77
-        assert tracker_msg['mac'] == '6A:6B:C9:A2:3E:43'
+        assert tracker_msg['mac'] == '6A6BC9A23E43'
         assert str(UUID(tracker_msg['uuid'])) == 'e2c56db5-dffb-48d2-b060-d0f5a71096e0'
         assert tracker_msg['uuid'] == 'e2c56db5dffb48d2b060d0f5a71096e0'
         assert tracker_msg['tracker_id'] == b'\xe2\xc5m\xb5\xdf\xfbH\xd2\xb0`\xd0\xf5\xa7\x10\x96\xe0'

--- a/package/tests/test_inkbird.py
+++ b/package/tests/test_inkbird.py
@@ -97,3 +97,39 @@ class TestInkbird:
         assert sensor_msg["humidity"] == 43.4
         assert sensor_msg["battery"] == 100
         assert sensor_msg["rssi"] == -52
+
+    def test_inkbird_IBS_TH2_T_only(self):
+        """Test Inkbird parser for Inkbird IBS-TH2/P01R."""
+        data_string = "043e1c02010400561d000742491004097470730affff0700000031603306c5"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Inkbird"
+        assert sensor_msg["type"] == "IBS-TH2/P01B"
+        assert sensor_msg["mac"] == "494207001D56"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 20.47
+        assert sensor_msg["battery"] == 51
+        assert sensor_msg["rssi"] == -59
+
+    def test_inkbird_IBS_TH2_T_only_2(self):
+        """Test Inkbird parser for Inkbird IBS-TH2/P01R."""
+        data_string = "043E2302010000242900074249170201060302F0FF04097470730AFF9EF8000000BCBC6406B7"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Inkbird"
+        assert sensor_msg["type"] == "IBS-TH2/P01B"
+        assert sensor_msg["mac"] == "494207002924"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == -18.9
+        assert sensor_msg["battery"] == 100
+        assert sensor_msg["rssi"] == -73

--- a/package/tests/test_laica.py
+++ b/package/tests/test_laica.py
@@ -1,0 +1,22 @@
+"""The tests for the Laica Smart Scale ble_parser."""
+from bleparser import BleParser
+
+
+class TestLaica:
+    """Tests for the Laica parser"""
+    def test_laica(self):
+        """Test Laica parser."""
+        data_string = "043e2b02010300a02bbe5e91a01f0201040303b0ff0fffaca0a02bbe5e91a0a02c92140dbf0709414141303032d9"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Laica"
+        assert sensor_msg["type"] == "Laica Smart Scale"
+        assert sensor_msg["mac"] == "A0915EBE2BA0"
+        assert sensor_msg["packet"] == "a02bbe5e91a0a02c92140dbf"
+        assert sensor_msg["data"]
+        assert sensor_msg["weight"] == 13.0
+        assert sensor_msg["rssi"] == -39

--- a/package/tests/test_miscale_parser.py
+++ b/package/tests/test_miscale_parser.py
@@ -3,11 +3,12 @@ from bleparser import BleParser
 
 
 class TestMiscale:
-
+    """Tests for the MiScale parser"""
     def test_miscale_v1(self):
         """Test Mi Scale v1 parser."""
         data_string = "043e2b020100008995c08c47c81f02010603021d1809ff5701c8478cc095890d161d18a22044b20701010a1a15c5"
         data = bytes(bytearray.fromhex(data_string))
+
         # pylint: disable=unused-variable
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
@@ -27,6 +28,7 @@ class TestMiscale:
         """Test Mi Scale v1 parser (extended advertisement)."""
         data_string = "043e390d011300008995c08c47c80100ff7fc70000000000000000001f02010603021d1809ff5701c8478cc095890d161d18821400e507040b101708"
         data = bytes(bytearray.fromhex(data_string))
+
         # pylint: disable=unused-variable
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
@@ -46,6 +48,7 @@ class TestMiscale:
         """Test Mi Scale v1 parser (extended advertisement) with stabilized weight."""
         data_string = "043e390d011300008995c08c47c80100ff7fba0000000000000000001f02010603021d1809ff5701c8478cc095890d161d18229e43e507040b101301"
         data = bytes(bytearray.fromhex(data_string))
+
         # pylint: disable=unused-variable
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
@@ -66,6 +69,7 @@ class TestMiscale:
         """Test Mi Scale v2 parser."""
         data_string = "043e2402010001ef148244dedf1802010603021b1810161b180204b207010112101a0000a852ae"
         data = bytes(bytearray.fromhex(data_string))
+
         # pylint: disable=unused-variable
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
@@ -83,8 +87,9 @@ class TestMiscale:
 
     def test_miscale_v2_impedance(self):
         """Test Mi Scale v2 parser."""
-        data_string = "043e2402010001ef148244dedf1802010603021b1810161b1802a6b20701011201128c01a852be"
+        data_string = "043e2402010001ef148244dedf1802010603021b1810161b180226b20705040f0201ac018642be"
         data = bytes(bytearray.fromhex(data_string))
+
         # pylint: disable=unused-variable
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
@@ -92,11 +97,11 @@ class TestMiscale:
         assert sensor_msg["firmware"] == "Mi Scale V2"
         assert sensor_msg["type"] == "Mi Scale V2"
         assert sensor_msg["mac"] == "DFDE448214EF"
-        assert sensor_msg["packet"] == "02a6b20701011201128c01a852"
+        assert sensor_msg["packet"] == "0226b20705040f0201ac018642"
         assert sensor_msg["data"]
-        assert sensor_msg["non-stabilized weight"] == 105.8
+        assert sensor_msg["non-stabilized weight"] == 85.15
         assert sensor_msg["weight unit"] == "kg"
-        assert sensor_msg["weight removed"] == 1
+        assert sensor_msg["weight removed"] == 0
         assert sensor_msg["stabilized"] == 1
-        assert sensor_msg["impedance"] == 396
+        assert sensor_msg["impedance"] == 428
         assert sensor_msg["rssi"] == -66

--- a/package/tests/test_relsib.py
+++ b/package/tests/test_relsib.py
@@ -1,0 +1,91 @@
+"""The tests for the Relsib ble_parser."""
+from bleparser import BleParser
+
+
+class TestRelsib:
+    """Tests for the Relsib parser"""
+    def test_relsib_AA20(self):
+        """Test Relsib parser for AA20 packet type."""
+        data_string = "043e2b0201030130ddf27cb6fa1f040945436f191620aa84000000b20a200a15030080f04700c2eb0b010b0300c2"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
+        assert sensor_msg["type"] == "EClerk Eco"
+        assert sensor_msg["mac"] == "FAB67CF2DD30"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 27.38
+        assert sensor_msg["humidity"] == 25.92
+        assert sensor_msg["co2"] == 789
+        assert sensor_msg["battery"] == 71
+        assert sensor_msg["rssi"] == -62
+
+    def test_relsib_AA21(self):
+        """Test Relsib parser for AA20 packet type."""
+        data_string = "043e2b0201030130ddf27cb6fa1f040945436f191621aa220a75094303008045636c65726b45636f0000000000b6"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
+        assert sensor_msg["type"] == "EClerk Eco"
+        assert sensor_msg["mac"] == "FAB67CF2DD30"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 25.94
+        assert sensor_msg["humidity"] == 24.21
+        assert sensor_msg["co2"] == 835
+        assert sensor_msg["rssi"] == -74
+
+    def test_relsib_AA22(self):
+        """Test Relsib parser for AA20 packet type."""
+        data_string = "043e2b0201030130ddf27cb6fa1f040945436f191622aa210a7509430300804f4f4f2052656c73696200000000bd"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
+        assert sensor_msg["type"] == "EClerk Eco"
+        assert sensor_msg["mac"] == "FAB67CF2DD30"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 25.93
+        assert sensor_msg["humidity"] == 24.21
+        assert sensor_msg["co2"] == 835
+        assert sensor_msg["rssi"] == -67
+
+    def test_relsib_no_data(self):
+        """Test Relsib parser for AA20 packet type during device startup when sensors are not ready yet."""
+        data_string = "043e2b0201030130ddf27cb6fa1f040945436f191620aa040000000080008000800080f04600c2eb0b010b0300be"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
+        assert sensor_msg["type"] == "EClerk Eco"
+        assert sensor_msg["mac"] == "FAB67CF2DD30"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert "temperature" not in sensor_msg
+        assert "humidity" not in sensor_msg
+        assert "co2" not in sensor_msg
+        assert sensor_msg["rssi"] == -66
+
+    def test_relsib_power_adapter_plugged(self):
+        """Test Relsib parser for AA20 packet type while using power adapter instead of battery."""
+        data_string = "043e2b0201030130ddf27cb6fa1f040945436f191620aa24080000200a750943030080f08000c2eb0b010b0300b6"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
+        assert sensor_msg["type"] == "EClerk Eco"
+        assert sensor_msg["mac"] == "FAB67CF2DD30"
+        assert sensor_msg["battery"] == 100

--- a/package/tests/test_sensirion.py
+++ b/package/tests/test_sensirion.py
@@ -14,10 +14,27 @@ class TestSensirion:
 
         assert sensor_msg["firmware"] == "Sensirion"
         assert sensor_msg["type"] == "MyCO2"
-        assert sensor_msg["mac"] == "F8:EA:DC:3C:67:35"
+        assert sensor_msg["mac"] == "F8EADC3C6735"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"] == True
         assert sensor_msg["temperature"] == 25.63
         assert sensor_msg["humidity"] == 36.16
         assert sensor_msg["co2"] == 1035
         assert sensor_msg["rssi"] == -80
+
+    def test_Sensorion_SHT4x(self):
+        """Test Sensirion SHT4x parser."""
+        data_string = "043e2902010001e7e2c3c067ff1d0201060bffd5060006e2e7036a1c650d09534854343020476164676574b9"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Sensirion"
+        assert sensor_msg["type"] == "SHT40 Gadget"
+        assert sensor_msg["mac"] == "FF67C0C3E2E7"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"] == True
+        assert sensor_msg["temperature"] == 27.47
+        assert sensor_msg["humidity"] == 39.5
+        assert sensor_msg["rssi"] == -71

--- a/package/tests/test_switchbot.py
+++ b/package/tests/test_switchbot.py
@@ -1,0 +1,41 @@
+"""The tests for the Switchbot ble_parser."""
+from bleparser import BleParser
+
+
+class TestSwitchbot:
+    """Tests for the Switchbot parser"""
+    def test_meter_th_s1(self):
+        """Test Switchbot parser for Meter TH S1."""
+        data_string = "043e2802010401f269352207ce1c11071bc5d5a50200b89fe6114d22000da2cb0916000d54006400990ec7"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Switchbot"
+        assert sensor_msg["type"] == "Meter TH S1"
+        assert sensor_msg["mac"] == "CE07223569F2"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 25.0
+        assert sensor_msg["humidity"] == 14
+        assert sensor_msg["battery"] == 100
+        assert sensor_msg["rssi"] == -57
+
+    def test_meter_th_plus(self):
+        """Test Switchbot parser for Meter TH plus."""
+        data_string = "043e160201040122df7526f9c40a09163dfd6900640098a6ac"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Switchbot"
+        assert sensor_msg["type"] == "Meter TH plus"
+        assert sensor_msg["mac"] == "C4F92675DF22"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 24.0
+        assert sensor_msg["humidity"] == 38
+        assert sensor_msg["battery"] == 100
+        assert sensor_msg["rssi"] == -84

--- a/package/tests/test_teltonika.py
+++ b/package/tests/test_teltonika.py
@@ -3,7 +3,7 @@ from bleparser import BleParser
 
 
 class TestTeltonika:
-
+    """Tests for the Teltonica parser"""
     def test_blue_puck_T(self):
         """Test Teltonika parser for Blue Puck T."""
         data_string = "043e1e02010001e7e193546ec61202010605166e2a860b08095055434b5f5431dd"
@@ -12,13 +12,13 @@ class TestTeltonika:
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
 
-        assert sensor_msg["firmware"], "Teltonika"
-        assert sensor_msg["type"], "Blue Puck T"
-        assert sensor_msg["mac"], "C66E5493E1E7"
-        assert sensor_msg["packet"], "no packet id"
+        assert sensor_msg["firmware"] == "Teltonika"
+        assert sensor_msg["type"] == "Blue Puck T"
+        assert sensor_msg["mac"] == "C66E5493E1E7"
+        assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"], 29.5
-        assert sensor_msg["rssi"], -35
+        assert sensor_msg["temperature"] == 29.5
+        assert sensor_msg["rssi"] == -35
 
     def test_blue_coin_T(self):
         """Test Teltonika parser for Blue Coin T."""
@@ -28,13 +28,13 @@ class TestTeltonika:
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
 
-        assert sensor_msg["firmware"], "Teltonika"
-        assert sensor_msg["type"], "Blue Coin T"
-        assert sensor_msg["mac"], "F02B026A8296"
-        assert sensor_msg["packet"], "no packet id"
+        assert sensor_msg["firmware"] == "Teltonika"
+        assert sensor_msg["type"] == "Blue Coin T"
+        assert sensor_msg["mac"] == "F02B026A8296"
+        assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"], 25.12
-        assert sensor_msg["rssi"], -47
+        assert sensor_msg["temperature"] == 25.12
+        assert sensor_msg["rssi"] == -47
 
     def test_blue_puck_RHT(self):
         """Test Teltonika parser for Blue Puck RHT."""
@@ -44,11 +44,11 @@ class TestTeltonika:
         ble_parser = BleParser()
         sensor_msg, tracker_msg = ble_parser.parse_data(data)
 
-        assert sensor_msg["firmware"], "Teltonika"
-        assert sensor_msg["type"], "Blue Puck RHT"
-        assert sensor_msg["mac"], "F02B026A8296"
-        assert sensor_msg["packet"], "no packet id"
+        assert sensor_msg["firmware"] == "Teltonika"
+        assert sensor_msg["type"] == "Blue Puck RHT"
+        assert sensor_msg["mac"] == "F02B026A8296"
+        assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"], 11.87
-        assert sensor_msg["humidity"], 35
-        assert sensor_msg["rssi"], -67
+        assert sensor_msg["temperature"] == 11.87
+        assert sensor_msg["humidity"] == 35
+        assert sensor_msg["rssi"] == -67

--- a/package/tests/test_tilt.py
+++ b/package/tests/test_tilt.py
@@ -1,0 +1,23 @@
+"""The tests for the Tilt ble_parser."""
+from bleparser import BleParser
+
+
+class TestTilt:
+    """Tests for the Tilt parser"""
+    def test_tilt_red(self):
+        """Test Tilt parser for Tilt Red."""
+        data_string = "043E27020100005A099B16A3041B1AFF4C000215A495BB10C5B14B44B5121370F02D74DE004403F8C5C7"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Tilt"
+        assert sensor_msg["type"] == "Tilt Red"
+        assert sensor_msg["mac"] == "04A3169B095A"
+        assert sensor_msg["uuid"] == "a495bb10c5b14b44b5121370f02d74de"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == 20.0
+        assert sensor_msg["gravity"] == 1.016
+        assert sensor_msg["rssi"] == -57

--- a/package/tests/test_xiaogui_parser.py
+++ b/package/tests/test_xiaogui_parser.py
@@ -4,8 +4,8 @@ from bleparser import BleParser
 
 class TestXiaogui:
     """Tests for the Xiaogui parser"""
-    def test_xiaogui_stab(self):
-        """Test Xiaogui parser (stabilized weight)."""
+    def test_xiaogui_tzc4_stab(self):
+        """Test Xiaogui parser for Xiaogui TZC4 (stabilized weight)."""
         data_string = "043e1d0201030094e0e5295a5f1110ffc0a30276138b0002215f5a29e5e094bd"
         data = bytes(bytearray.fromhex(data_string))
 
@@ -24,8 +24,8 @@ class TestXiaogui:
         assert sensor_msg["stabilized"] == 1
         assert sensor_msg["rssi"] == -67
 
-    def test_xiaogui_non_stab(self):
-        """Test Xiaogui parser (not stabilized weight)."""
+    def test_xiaogui_tzc4_non_stab(self):
+        """Test Xiaogui parser for Xiaogui TZC4 (not stabilized weight)."""
         data_string = "043e1d0201030094e0e5295a5f1110ffc05d008c00000002205f5a29e5e094bf"
         data = bytes(bytearray.fromhex(data_string))
 
@@ -43,3 +43,42 @@ class TestXiaogui:
         assert "impedance" not in sensor_msg
         assert sensor_msg["stabilized"] == 0
         assert sensor_msg["rssi"] == -65
+
+    def test_xiaogui_maxxmee_qjj_stab(self):
+        """Test Xiaogui parser for MaxxMee Mod QJ-J (stabilized weight)."""
+        data_string = "043e1d0201030094e0e5295a5f1110ffc07d2c4700000a01255f5a29e5e094bd"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Xiaogui"
+        assert sensor_msg["type"] == "QJ-J"
+        assert sensor_msg["mac"] == "5F5A29E5E094"
+        assert sensor_msg["packet"] == 32037
+        assert sensor_msg["data"]
+        assert sensor_msg["non-stabilized weight"] == 113.35
+        assert sensor_msg["weight"] == 113.35
+        assert sensor_msg["stabilized"] == 1
+        assert sensor_msg["rssi"] == -67
+
+    def test_xiaogui_maxxmee_qjj_non_stab(self):
+        """Test Xiaogui parser for MaxxMee Mod QJ-J (not stabilized weight)."""
+        data_string = "043e1d0201030094e0e5295a5f1110ffc024000000000a01245f5a29e5e094bd"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+
+        assert sensor_msg["firmware"] == "Xiaogui"
+        assert sensor_msg["type"] == "QJ-J"
+        assert sensor_msg["mac"] == "5F5A29E5E094"
+        assert sensor_msg["packet"] == 9252
+        assert sensor_msg["data"]
+        assert sensor_msg["non-stabilized weight"] == 0.0
+        assert "weight" not in sensor_msg
+        assert "impedance" not in sensor_msg
+        assert sensor_msg["stabilized"] == 0
+        assert sensor_msg["rssi"] == -67

--- a/package/tests/test_xiaomi_parser.py
+++ b/package/tests/test_xiaomi_parser.py
@@ -407,7 +407,7 @@ class TestXiaomi:
         assert sensor_msg["mac"] == "D71F44EB8A91"
         assert sensor_msg["packet"] == 67
         assert sensor_msg["data"]
-        assert sensor_msg["lock"] == 0
+        assert sensor_msg["lock"] == 1
         assert sensor_msg["action"] == "unlock outside the door"
         assert sensor_msg["method"] == "biometrics"
         assert sensor_msg["error"] is None

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,1 +1,1 @@
-pycryptodomex==3.12.0
+pycryptodomex==3.14.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bleparser
-version = 2.0.0
+version = 3.0.0
 author = Ernst79
 author_email = e.klamer@gmail.com
 description = Parser for passive BLE advertisements


### PR DESCRIPTION
## April update

This update brings bleparser in line with the parser in BLE monitor 8.6.1 and contains the following changes:

**BREAKING CHANGES**
- Xiaomi ZNMS17LM
  
  Lock states were reversed for the binary (lock) sensor: 0=>locked 1=>unlocked. This release fixes that issue. This applies to all all Xiaomi locks, although it has only been tested on the ZNMS17LM model (by @vincent-k).

  ZNMS17LM is reporting lock, anti-lock & child-lock events. Using these on the same sensor/lock leads
to an incorrect global state. Eg. when the door is fully locked (main lock + anti-lock), if we release only the anti-lock then the sensor goes to unlocked state which is incorrect. This commit decouples the lock into three distinct sensors: 'lock', 'anti-lock' & 'child-lock' to avoid such issues (by @vincent-k).

  Note: this only targets ZNMS17LM model to keep a selective approach (some users may prefer the global version and some other Xiaomi locks may not be reporting those states).

- iBeacon, Altbeacon
  
  iBeacon parser were showing the formatted mac address in the parser output, they now show the unformatted MAC address (without colons)
 

**new sensors**
- HA BLE diy sensors (see below)
- MaxxMee Mod: QJ-J scale
- HHCC plant sensor HHCCJCY10
- Laica Smart Scale (PS7011/PS7020) sensors
- Tilt sensors
- Sensirion SHT4x
- Inkbird P01B pool thermometer
- Air Mentor pro 2
- Switchbot Meter TH S1
- Relsib EClerk Eco
- Inkbird IBS-TH2 without humidity (temperature only)
- Govee H5071
- ATC firmware on CGDK2
- Acconeer XM12 motion sensor

**new features**
- Add door sensor for ZNMS16LM/ZNMS17LM

**bug fixes**
- Fix for Inkbird IBS-TH(2) not being recognized in some cases
- Fix for negative temperatures reported by b-parasites and v2 support
- Fix for iBBQ sensors not reporting temperatures above 100°C
- Improved Mi Scale V2 behavior
- Fix for Oral-B when sending an non-defined state
- Fix for short Altbeacon advertismement
- Add extra filter for Teltonika Puck RHT
- Bump pycryptodomex to 3.14.1
- Improved Qingping CGDN1 support


**New HA BLE format**
This release brings a totally new HA BLE format. We have created a BLE advertisement format that you can use for your DIY sensors. The main advantages of the new format:
- Developed by the makers of BLE monitor, so fully supported
- Flexible format (choose your own number of digits, data size)
- Supports encryption (if you want)
- Energy efficient. We tried to make a format that is as short as possible, to reduce energy consumption, but at the same time to be as flexible as possible
- Support for a wide range of sensor types (and others can be added easily)
- More info about the format can be found [here](https://github.com/custom-components/ble_monitor/blob/new-HA_BLE/docs/ha_ble.md)

- Thanks for @pvvx for his suggestions on how to improve the HA BLE format. [ATC firmware 3.7(b)](https://github.com/pvvx/ATC_MiThermometer) has added support for HA BLE format in the sensors that support ATC firmware.
