### PR TITLE
Update parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ A full list of all supported sensors can be found on the [BLE monitor documentat
 
 ## Usage
 
-When using default input parameters, you can use bleparser as follows (more working examples below). 
+When using default input parameters, you can use bleparser with raw BLE data as follows (more working examples below). 
 
 ```python
 ble_parser = BleParser()
-sensor_msg, tracker_msg = ble_parser.parse_data(data)
+sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 ```
 
 You can set optional parameters, the example below shows all possible input parameters with default values.
@@ -68,7 +68,25 @@ ble_parser = BleParser(
     tracker_whitelist=[],
     aeskeys={}
     )
+sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 ```
+
+It is also possible to use advertisement data directly. 
+
+```python
+ble_parser = BleParser()
+sensor_data, tracker_data = self.parse_advertisement(
+    mac,
+    rssi,
+    service_class_uuid16,
+    service_class_uuid128,
+    local_name,
+    service_data_list,
+    man_spec_data_list
+)
+```
+
+`service_data_list` and `man_spec_data_list` have to be in a list, as a BKE advertisement can contain multiple service data/manufacturer specific data packets. 
 
 **report_unknown**
 
@@ -109,7 +127,7 @@ data_string = "043e2502010000219335342d5819020106151695fe5020aa01da219335342d580
 data = bytes(bytearray.fromhex(data_string))
 
 ble_parser = BleParser()
-sensor_msg, tracker_msg = ble_parser.parse_data(data)
+sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 print(sensor_msg)
 ```
 
@@ -137,7 +155,7 @@ track_mac = bytes.fromhex(track_mac.replace(":", ""))
 tracker_whitelist.append(track_mac.lower())
 
 ble_parser = BleParser(tracker_whitelist=tracker_whitelist)
-sensor_msg, tracker_msg = ble_parser.parse_data(data)
+sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 print(tracker_msg)
 ```
 

--- a/examples/ble2mqtt.py
+++ b/examples/ble2mqtt.py
@@ -66,7 +66,7 @@ SENSOR_BUFFER = defaultdict(dict)
 
 ## Define callback
 def process_hci_events(data):
-    sensor_data, tracker_data = parser.parse_data(data)
+    sensor_data, tracker_data = parser.parse_raw_data(data)
 
     if tracker_data:
         mac = ':'.join(wrap(tracker_data.pop("mac"), 2))

--- a/package/bleparser/switchbot.py
+++ b/package/bleparser/switchbot.py
@@ -16,13 +16,13 @@ def parse_switchbot(self, data, source_mac, rssi):
     switchbot_mac = source_mac
     device_id = data[4] + (data[5] << 8)
 
-    if msg_length == 10 and device_id in [0x0054, 0x0069]:
+    if msg_length == 10 and device_id in [0x0054, 0x0069, 0x1054]:
         xvalue = data[6:10]
         (byte1, byte2, byte3, byte4) = unpack("<BBBB", xvalue)
         batt = (byte1 & 127)
         temp = float(byte3 - 128) + float(byte2 / 10.0)
         humi = (byte4 & 127)
-        if device_id == 0x0054:
+        if device_id in [0x0054, 0x1054]:
             device_type = "Meter TH S1"
         elif device_id == 0x0069:
             device_type = "Meter TH plus"

--- a/package/bleparser/xiaomi.py
+++ b/package/bleparser/xiaomi.py
@@ -33,6 +33,7 @@ XIAOMI_TYPE_DICT = {
     0x0DFD: "K9B-3BTN",
     0x01AA: "LYWSDCGQ",
     0x045B: "LYWSD02",
+    0x16e4: "LYWSD02MMC",
     0x055B: "LYWSD03MMC",
     0x098B: "MCCGQ02HL",
     0x06d3: "MHO-C303",
@@ -205,6 +206,7 @@ def obj0007(xobj):
         return {}
     return {"door": door, "door action": action}
 
+
 def obj0008(xobj, device_type):
     """armed away"""
     returnData = {}
@@ -226,6 +228,7 @@ def obj0008(xobj, device_type):
             "timestamp": None,
         }
     return returnData
+
 
 def obj0010(xobj):
     """Toothbrush"""
@@ -269,7 +272,7 @@ def obj000b(xobj, device_type):
         action = BLE_LOCK_ACTION[action][2]
         method = BLE_LOCK_METHOD[method]
 
-        #Biometric unlock then disarm
+        # Biometric unlock then disarm
         if device_type == "DSL-C08":
             if method == "password":
                 if 5000 <= key_id < 6000:
@@ -605,6 +608,7 @@ def obj100d(xobj):
     else:
         return {}
 
+
 def obj100e(xobj, device_type):
     """Lock common attribute"""
     # https://iot.mi.com/new/doc/accesses/direct-access/embedded-development/ble/object-definition#%E9%94%81%E5%B1%9E%E6%80%A7
@@ -615,6 +619,7 @@ def obj100e(xobj, device_type):
             lock = lock_attribute & 0x01 ^ 1
             childlock = lock_attribute >> 3 ^ 1
             return {"childlock": childlock, "lock": lock}
+
 
 def obj2000(xobj):
     """Body temperature"""
@@ -632,7 +637,7 @@ def obj2000(xobj):
         return {}
 
 
-# The following data objects are device specific. For now only added for XMWSDJ04MMC and XMWXKG01YL
+# The following data objects are device specific. For now only added for LYWSD02MMC, XMWSDJ04MMC, XMWXKG01YL
 # https://miot-spec.org/miot-spec-v2/instances?status=all
 def obj4803(xobj):
     """Battery"""
@@ -651,6 +656,15 @@ def obj4c01(xobj):
     if len(xobj) == 4:
         temp = FLOAT_STRUCT.unpack(xobj)[0]
         return {"temperature": temp}
+    else:
+        return {}
+
+
+def obj4c02(xobj):
+    """Humidity"""
+    if len(xobj) == 1:
+        humi = xobj[0]
+        return {"humidity": humi}
     else:
         return {}
 
@@ -768,6 +782,7 @@ xiaomi_dataobject_dict = {
     0x4803: obj4803,
     0x4a01: obj4a01,
     0x4c01: obj4c01,
+    0x4c02: obj4c02,
     0x4c08: obj4c08,
     0x4c14: obj4c14,
     0x4e0c: obj4e0c,
@@ -967,7 +982,7 @@ def parse_xiaomi(self, data, source_mac, rssi):
             if obj_length != 0:
                 resfunc = xiaomi_dataobject_dict.get(obj_typecode, None)
                 if resfunc:
-                    if hex(obj_typecode) in ["0x8","0x100e","0x1001", "0xf", "0xb"]:
+                    if hex(obj_typecode) in ["0x8", "0x100e", "0x1001", "0xf", "0xb"]:
                         result.update(resfunc(dobject, device_type))
                     else:
                         result.update(resfunc(dobject))

--- a/package/tests/test_acconeer.py
+++ b/package/tests/test_acconeer.py
@@ -12,7 +12,7 @@ class TestAcconeer:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Acconeer"
         assert sensor_msg["type"] == "Acconeer XM122"

--- a/package/tests/test_airmentor.py
+++ b/package/tests/test_airmentor.py
@@ -10,7 +10,7 @@ class TestAirMentor:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Air Mentor"
         assert sensor_msg["type"] == "Air Mentor Pro 2"
@@ -31,7 +31,7 @@ class TestAirMentor:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Air Mentor"
         assert sensor_msg["type"] == "Air Mentor Pro 2"

--- a/package/tests/test_almendo.py
+++ b/package/tests/test_almendo.py
@@ -10,7 +10,7 @@ class TestAlmendo:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Almendo V1"
         assert sensor_msg["type"] == "bluSensor Mini"

--- a/package/tests/test_altbeacon_parser.py
+++ b/package/tests/test_altbeacon_parser.py
@@ -13,7 +13,7 @@ class TestAltBeacon:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg['type'] == 'AltBeacon'
         assert sensor_msg['packet'] == 'no packet id'
@@ -34,7 +34,7 @@ class TestAltBeacon:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser(tracker_whitelist=[bytearray.fromhex('d3162f5af3ee494799db09756062d0fc')])
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg['type'] == 'AltBeacon'
         assert sensor_msg['packet'] == 'no packet id'

--- a/package/tests/test_atc_parser.py
+++ b/package/tests/test_atc_parser.py
@@ -11,7 +11,7 @@ class TestATC:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "ATC (Atc1441)"
         assert sensor_msg["type"] == "ATC"
@@ -30,7 +30,7 @@ class TestATC:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "ATC (Atc1441)"
         assert sensor_msg["type"] == "ATC"
@@ -49,7 +49,7 @@ class TestATC:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "ATC (Custom)"
         assert sensor_msg["type"] == "ATC"
@@ -68,7 +68,7 @@ class TestATC:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "ATC (Custom)"
         assert sensor_msg["type"] == "ATC"
@@ -87,7 +87,7 @@ class TestATC:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "ATC (Custom)"
         assert sensor_msg["type"] == "ATC"
@@ -116,7 +116,7 @@ class TestATC:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "ATC (Custom encrypted)"
         assert sensor_msg["type"] == "ATC"

--- a/package/tests/test_bluemaestro.py
+++ b/package/tests/test_bluemaestro.py
@@ -9,7 +9,7 @@ class TestBlueMaestro:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "BlueMaestro"
         assert sensor_msg["type"] == "Tempo Disc THD"

--- a/package/tests/test_bparasite.py
+++ b/package/tests/test_bparasite.py
@@ -11,7 +11,7 @@ class TestBParasite:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "b-parasite V1.1.0 (with illuminance)"
         assert sensor_msg["type"] == "b-parasite V1.1.0"
@@ -31,7 +31,7 @@ class TestBParasite:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "b-parasite V1.0.0 (without illuminance)"
         assert sensor_msg["type"] == "b-parasite V1.0.0"

--- a/package/tests/test_brifit_parser.py
+++ b/package/tests/test_brifit_parser.py
@@ -10,7 +10,7 @@ class TestBrifit:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"], "Brifit"
         assert sensor_msg["type"], "T201"

--- a/package/tests/test_govee_parser.py
+++ b/package/tests/test_govee_parser.py
@@ -10,7 +10,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5051/H5071"
@@ -28,7 +28,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5074"
@@ -46,7 +46,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5101/H5102/H5177"
@@ -64,7 +64,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5072/H5075"
@@ -82,7 +82,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5072/H5075"
@@ -100,7 +100,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5178"
@@ -119,7 +119,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5178-outdoor"
@@ -138,7 +138,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5179"
@@ -156,7 +156,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5182"
@@ -175,7 +175,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5182"
@@ -194,7 +194,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5183"
@@ -212,7 +212,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5185"
@@ -231,7 +231,7 @@ class TestGovee:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Govee"
         assert sensor_msg["type"] == "H5185"

--- a/package/tests/test_ha_ble.py
+++ b/package/tests/test_ha_ble.py
@@ -11,7 +11,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -28,7 +28,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -53,7 +53,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys, discovery=False, sensor_whitelist=allow_list)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE (encrypted)"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -71,7 +71,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -88,7 +88,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -105,7 +105,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -123,7 +123,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -140,7 +140,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -157,7 +157,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -174,7 +174,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -191,7 +191,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -209,7 +209,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -226,7 +226,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -243,7 +243,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -260,7 +260,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -278,7 +278,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"
@@ -295,7 +295,7 @@ class TestHaBle:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HA BLE"
         assert sensor_msg["type"] == "HA BLE DIY"

--- a/package/tests/test_hhcc.py
+++ b/package/tests/test_hhcc.py
@@ -11,7 +11,7 @@ class TestHHCC:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "HHCC"
         assert sensor_msg["type"] == "HHCCJCY10"

--- a/package/tests/test_ibeacon_parser.py
+++ b/package/tests/test_ibeacon_parser.py
@@ -13,7 +13,7 @@ class TestIBeacon:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg['type'] == 'iBeacon'
         assert sensor_msg['packet'] == 'no packet id'
@@ -35,7 +35,7 @@ class TestIBeacon:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser(tracker_whitelist=[bytearray.fromhex('e2c56db5dffb48d2b060d0f5a71096e0')])
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert tracker_msg['is connected']
         assert tracker_msg['rssi'] == -77
@@ -56,7 +56,7 @@ class TestIBeacon:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg is None
         assert tracker_msg is None
@@ -67,7 +67,7 @@ class TestIBeacon:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg is None
         assert tracker_msg is None

--- a/package/tests/test_inkbird.py
+++ b/package/tests/test_inkbird.py
@@ -11,7 +11,7 @@ class TestInkbird:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Inkbird"
         assert sensor_msg["type"] == "iBBQ-1"
@@ -28,7 +28,7 @@ class TestInkbird:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Inkbird"
         assert sensor_msg["type"] == "iBBQ-2"
@@ -46,7 +46,7 @@ class TestInkbird:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Inkbird"
         assert sensor_msg["type"] == "iBBQ-4"
@@ -66,7 +66,7 @@ class TestInkbird:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Inkbird"
         assert sensor_msg["type"] == "iBBQ-6"
@@ -86,7 +86,7 @@ class TestInkbird:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Inkbird"
         assert sensor_msg["type"] == "IBS-TH"
@@ -105,7 +105,7 @@ class TestInkbird:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Inkbird"
         assert sensor_msg["type"] == "IBS-TH2/P01B"
@@ -123,7 +123,7 @@ class TestInkbird:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Inkbird"
         assert sensor_msg["type"] == "IBS-TH2/P01B"

--- a/package/tests/test_inode_parser.py
+++ b/package/tests/test_inode_parser.py
@@ -11,7 +11,7 @@ class TestInode:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "iNode"
         assert sensor_msg["type"] == "iNode Energy Meter"
@@ -37,7 +37,7 @@ class TestInode:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "iNode"
         assert sensor_msg["type"] == "iNode Care Sensor 1"
@@ -61,7 +61,7 @@ class TestInode:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "iNode"
         assert sensor_msg["type"] == "iNode Care Sensor HT"

--- a/package/tests/test_jinou.py
+++ b/package/tests/test_jinou.py
@@ -11,7 +11,7 @@ class TestJinou:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Jinou"
         assert sensor_msg["type"] == "BEC07-5"

--- a/package/tests/test_kegtron_parser.py
+++ b/package/tests/test_kegtron_parser.py
@@ -10,7 +10,7 @@ class TestKegtron:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Kegtron"
         assert sensor_msg["type"] == "Kegtron KT-100"
@@ -32,7 +32,7 @@ class TestKegtron:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Kegtron"
         assert sensor_msg["type"] == "Kegtron KT-200"

--- a/package/tests/test_kkm.py
+++ b/package/tests/test_kkm.py
@@ -11,7 +11,7 @@ class TestKKM:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "KKM"
         assert sensor_msg["type"] == "K6 Sensor Beacon"

--- a/package/tests/test_laica.py
+++ b/package/tests/test_laica.py
@@ -11,7 +11,7 @@ class TestLaica:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Laica"
         assert sensor_msg["type"] == "Laica Smart Scale"

--- a/package/tests/test_mikrotik.py
+++ b/package/tests/test_mikrotik.py
@@ -11,7 +11,7 @@ class TestLaica:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Mikrotik"
         assert sensor_msg["type"] == "TG-BT5-IN"
@@ -41,7 +41,7 @@ class TestLaica:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Mikrotik"
         assert sensor_msg["type"] == "TG-BT5-OUT"

--- a/package/tests/test_miscale_parser.py
+++ b/package/tests/test_miscale_parser.py
@@ -11,7 +11,7 @@ class TestMiscale:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Mi Scale V1"
         assert sensor_msg["type"] == "Mi Scale V1"
@@ -31,7 +31,7 @@ class TestMiscale:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Mi Scale V1"
         assert sensor_msg["type"] == "Mi Scale V1"
@@ -51,7 +51,7 @@ class TestMiscale:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Mi Scale V1"
         assert sensor_msg["type"] == "Mi Scale V1"
@@ -72,7 +72,7 @@ class TestMiscale:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Mi Scale V2"
         assert sensor_msg["type"] == "Mi Scale V2"
@@ -92,7 +92,7 @@ class TestMiscale:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Mi Scale V2"
         assert sensor_msg["type"] == "Mi Scale V2"

--- a/package/tests/test_moat_parser.py
+++ b/package/tests/test_moat_parser.py
@@ -9,7 +9,7 @@ class TestMoat:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Moat"
         assert sensor_msg["type"] == "Moat S2"

--- a/package/tests/test_oral_b.py
+++ b/package/tests/test_oral_b.py
@@ -11,7 +11,7 @@ class TestOralB:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
         print(sensor_msg)
         assert sensor_msg["firmware"] == "Oral-B"
         assert sensor_msg["type"] == "SmartSeries 7000"

--- a/package/tests/test_qingping_parser.py
+++ b/package/tests/test_qingping_parser.py
@@ -10,7 +10,7 @@ class TestQingping:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Qingping"
         assert sensor_msg["type"] == "CGP1W"
@@ -29,7 +29,7 @@ class TestQingping:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Qingping"
         assert sensor_msg["type"] == "CGD1"
@@ -47,7 +47,7 @@ class TestQingping:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Qingping"
         assert sensor_msg["type"] == "CGG1"
@@ -65,7 +65,7 @@ class TestQingping:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Qingping"
         assert sensor_msg["type"] == "CGPR1"
@@ -82,7 +82,7 @@ class TestQingping:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Qingping"
         assert sensor_msg["type"] == "CGPR1"
@@ -99,7 +99,7 @@ class TestQingping:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Qingping"
         assert sensor_msg["type"] == "CGPR1"
@@ -115,7 +115,7 @@ class TestQingping:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg is None
 
@@ -125,7 +125,7 @@ class TestQingping:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Qingping"
         assert sensor_msg["type"] == "CGDN1"

--- a/package/tests/test_relsib.py
+++ b/package/tests/test_relsib.py
@@ -10,7 +10,7 @@ class TestRelsib:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
         assert sensor_msg["type"] == "EClerk Eco"
@@ -29,7 +29,7 @@ class TestRelsib:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
         assert sensor_msg["type"] == "EClerk Eco"
@@ -47,7 +47,7 @@ class TestRelsib:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
         assert sensor_msg["type"] == "EClerk Eco"
@@ -65,7 +65,7 @@ class TestRelsib:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
         assert sensor_msg["type"] == "EClerk Eco"
@@ -83,7 +83,7 @@ class TestRelsib:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Relsib (EClerk Eco v9a)"
         assert sensor_msg["type"] == "EClerk Eco"

--- a/package/tests/test_ruuvitag_parser.py
+++ b/package/tests/test_ruuvitag_parser.py
@@ -10,7 +10,7 @@ class TestRuuviTag:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Ruuvitag V2"
         assert sensor_msg["type"] == "Ruuvitag"
@@ -28,7 +28,7 @@ class TestRuuviTag:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Ruuvitag V3"
         assert sensor_msg["type"] == "Ruuvitag"
@@ -52,7 +52,7 @@ class TestRuuviTag:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Ruuvitag V4"
         assert sensor_msg["type"] == "Ruuvitag"
@@ -71,7 +71,7 @@ class TestRuuviTag:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Ruuvitag V5"
         assert sensor_msg["type"] == "Ruuvitag"

--- a/package/tests/test_sensirion.py
+++ b/package/tests/test_sensirion.py
@@ -10,7 +10,7 @@ class TestSensirion:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Sensirion"
         assert sensor_msg["type"] == "MyCO2"
@@ -28,7 +28,7 @@ class TestSensirion:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Sensirion"
         assert sensor_msg["type"] == "SHT40 Gadget"

--- a/package/tests/test_sensorpush.py
+++ b/package/tests/test_sensorpush.py
@@ -10,7 +10,7 @@ class TestSensorPush:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "SensorPush"
         assert sensor_msg["type"] == "HT.w"
@@ -28,7 +28,7 @@ class TestSensorPush:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "SensorPush"
         assert sensor_msg["type"] == "HTP.xw"

--- a/package/tests/test_switchbot.py
+++ b/package/tests/test_switchbot.py
@@ -10,7 +10,7 @@ class TestSwitchbot:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Switchbot"
         assert sensor_msg["type"] == "Meter TH S1"
@@ -28,7 +28,7 @@ class TestSwitchbot:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Switchbot"
         assert sensor_msg["type"] == "Meter TH plus"

--- a/package/tests/test_teltonika.py
+++ b/package/tests/test_teltonika.py
@@ -10,7 +10,7 @@ class TestTeltonika:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Teltonika"
         assert sensor_msg["type"] == "Blue Puck T"
@@ -26,7 +26,7 @@ class TestTeltonika:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Teltonika"
         assert sensor_msg["type"] == "Blue Coin T"
@@ -42,7 +42,7 @@ class TestTeltonika:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Teltonika"
         assert sensor_msg["type"] == "Blue Puck RHT"

--- a/package/tests/test_thermoplus_parser.py
+++ b/package/tests/test_thermoplus_parser.py
@@ -10,7 +10,7 @@ class TestThermoplus:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Thermoplus"
         assert sensor_msg["type"] == "Smart hygrometer"
@@ -29,7 +29,7 @@ class TestThermoplus:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Thermoplus"
         assert sensor_msg["type"] == "Lanyard/mini hygrometer"

--- a/package/tests/test_thermopro.py
+++ b/package/tests/test_thermopro.py
@@ -10,7 +10,7 @@ class TestThermoplus:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Thermopro"
         assert sensor_msg["type"] == "TP359"

--- a/package/tests/test_tilt.py
+++ b/package/tests/test_tilt.py
@@ -10,7 +10,7 @@ class TestTilt:
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Tilt"
         assert sensor_msg["type"] == "Tilt Red"

--- a/package/tests/test_xiaogui_parser.py
+++ b/package/tests/test_xiaogui_parser.py
@@ -11,7 +11,7 @@ class TestXiaogui:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaogui"
         assert sensor_msg["type"] == "TZC4"
@@ -31,7 +31,7 @@ class TestXiaogui:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaogui"
         assert sensor_msg["type"] == "TZC4"
@@ -51,7 +51,7 @@ class TestXiaogui:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaogui"
         assert sensor_msg["type"] == "QJ-J"
@@ -70,7 +70,7 @@ class TestXiaogui:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaogui"
         assert sensor_msg["type"] == "QJ-J"

--- a/package/tests/test_xiaomi_parser.py
+++ b/package/tests/test_xiaomi_parser.py
@@ -12,7 +12,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V2)"
         assert sensor_msg["type"] == "LYWSDCGQ"
@@ -38,7 +38,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys, discovery=False, sensor_whitelist=allow_list)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V5 encrypted)"
         assert sensor_msg["type"] == "CGG1-ENCRYPTED"
@@ -64,7 +64,7 @@ class TestXiaomi:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V5 encrypted)"
         assert sensor_msg["type"] == "CGDK2"
@@ -77,6 +77,32 @@ class TestXiaomi:
     def test_Xiaomi_LYWSD02(self):
         """Test Xiaomi parser for LYWSD02."""
 
+    def test_Xiaomi_LYWSD02MMC(self):
+        """Test Xiaomi parser for LYWSD02MMC."""
+        self.aeskeys = {}
+        data_string = "043e290201000084535638c1a41d020106191695fe5858e4162c84535638c1a42b6ef2e91200006c884d9eb0"
+        data = bytes(bytearray.fromhex(data_string))
+
+        aeskey = "a115210eed7a88e50ad52662e732a9fb"
+
+        is_ext_packet = True if data[3] == 0x0D else False
+        mac = (data[8 if is_ext_packet else 7:14 if is_ext_packet else 13])[::-1]
+        mac_address = mac.hex()
+        p_mac = bytes.fromhex(mac_address.replace(":", "").lower())
+        p_key = bytes.fromhex(aeskey.lower())
+        self.aeskeys[p_mac] = p_key
+        # pylint: disable=unused-variable
+        ble_parser = BleParser(aeskeys=self.aeskeys)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V5 encrypted)"
+        assert sensor_msg["type"] == "LYWSD02MMC"
+        assert sensor_msg["mac"] == "A4C138565384"
+        assert sensor_msg["packet"] == 44
+        assert sensor_msg["data"]
+        assert sensor_msg["humidity"] == 58
+        assert sensor_msg["rssi"] == -80
+
     def test_Xiaomi_LYWSD03MMC(self):
         """Test Xiaomi parser for LYWSD03MMC without encryption."""
         data_string = "043e22020100004c94b438c1a416151695fe50305b05034c94b438c1a40d10041001ea01cf"
@@ -84,7 +110,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V3)"
         assert sensor_msg["type"] == "LYWSD03MMC"
@@ -111,7 +137,7 @@ class TestXiaomi:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V5 encrypted)"
         assert sensor_msg["type"] == "LYWSD03MMC"
@@ -137,7 +163,7 @@ class TestXiaomi:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V5 encrypted)"
         assert sensor_msg["type"] == "XMWSDJ04MMC"
@@ -154,7 +180,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V3)"
         assert sensor_msg["type"] == "XMMF01JQD"
@@ -198,7 +224,7 @@ class TestXiaomi:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V5 encrypted)"
         assert sensor_msg["type"] == "JTYJGD03MI"
@@ -224,7 +250,7 @@ class TestXiaomi:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V5 encrypted)"
         assert sensor_msg["type"] == "JTYJGD03MI"
@@ -241,7 +267,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V2)"
         assert sensor_msg["type"] == "HHCCJCY01"
@@ -258,7 +284,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V2)"
         assert sensor_msg["type"] == "GCLS002"
@@ -299,7 +325,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V3)"
         assert sensor_msg["type"] == "MUE4094RT"
@@ -326,7 +352,7 @@ class TestXiaomi:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V5 encrypted)"
         assert sensor_msg["type"] == "RTCGQ02LM"
@@ -345,7 +371,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V2)"
         assert sensor_msg["type"] == "MMC-T201-1"
@@ -363,7 +389,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V3)"
         assert sensor_msg["type"] == "M1S-T500"
@@ -381,7 +407,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V4)"
         assert sensor_msg["type"] == "ZNMS16LM"
@@ -400,7 +426,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V4)"
         assert sensor_msg["type"] == "ZNMS16LM"
@@ -424,7 +450,7 @@ class TestXiaomi:
 
         # pylint: disable=unused-variable
         ble_parser = BleParser()
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V3)"
         assert sensor_msg["type"] == "YLYK01YL"
@@ -461,7 +487,7 @@ class TestXiaomi:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V3 encrypted)"
         assert sensor_msg["type"] == "YLKG07YL/YLKG08YL"
@@ -488,7 +514,7 @@ class TestXiaomi:
         self.aeskeys[p_mac] = p_key
         # pylint: disable=unused-variable
         ble_parser = BleParser(aeskeys=self.aeskeys)
-        sensor_msg, tracker_msg = ble_parser.parse_data(data)
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
 
         assert sensor_msg["firmware"] == "Xiaomi (MiBeacon V3 encrypted)"
         assert sensor_msg["type"] == "YLKG07YL/YLKG08YL"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bleparser
-version = 3.2.0
+version = 3.3.0
 author = Ernst79
 author_email = e.klamer@gmail.com
 description = Parser for passive BLE advertisements


### PR DESCRIPTION
## Breaking changes in PR

- Modified the ble-parser to be able to accept non-raw BLE data. This change doesn't affect BLE monitor, but prepares for future changes in Home Assistant. RAW ble advertisements now have to be parsed with `parse_raw_data` instead of `Breaking change, `parse_data` becomes `parse_raw_data`)
- Add support for LYWSD02MMC Xiaomi temperature and humidity clock
- Add support for Swichbot Meter TH S1 with new device_id (0x1054)