### PR TITLE
Fix unbound local var with Inkbird@IBBQ-4BW

### DIFF
--- a/package/bleparser/inkbird.py
+++ b/package/bleparser/inkbird.py
@@ -46,6 +46,8 @@ def parse_inkbird(self, data, complete_local_name, source_mac, rssi):
                     "battery": bat,
                 }
             )
+        else:
+            return None
     elif msg_length == 14:
         device_type = "iBBQ-1"
         inkbird_mac = data[6:12]


### PR DESCRIPTION
The data it sends is b'\x00\x00\x01\x10\x11$\x9f\x89\xed\xe0"'
which happens to be 11 bytes but it does not have the sps or tps in name