### PR TITLE
preserve compatiblity with python 3.8

### DIFF
--- a/package/bleparser/altbeacon.py
+++ b/package/bleparser/altbeacon.py
@@ -47,15 +47,18 @@ def parse_altbeacon(self, data: str, comp_id: int, source_mac: str, rssi: float)
             CONF_MEASURED_POWER: power,
         }
 
-        sensor_data = {
-            CONF_TYPE: DEVICE_TYPE,
-            CONF_PACKET: "no packet id",
-            CONF_FIRMWARE: DEVICE_TYPE,
-            CONF_MANUFACTURER: MANUFACTURER_DICT[comp_id] \
-                if comp_id in MANUFACTURER_DICT \
-                else DEFAULT_MANUFACTURER,
-            CONF_DATA: True
-        } | tracker_data
+        sensor_data = dict(
+            {
+                CONF_TYPE: DEVICE_TYPE,
+                CONF_PACKET: "no packet id",
+                CONF_FIRMWARE: DEVICE_TYPE,
+                CONF_MANUFACTURER: MANUFACTURER_DICT[comp_id] \
+                    if comp_id in MANUFACTURER_DICT \
+                    else DEFAULT_MANUFACTURER,
+                CONF_DATA: True
+            },
+            **tracker_data
+        )
     else:
         if self.report_unknown == DEVICE_TYPE:
             _LOGGER.info(

--- a/package/bleparser/ibeacon.py
+++ b/package/bleparser/ibeacon.py
@@ -47,12 +47,15 @@ def parse_ibeacon(self, data: str, source_mac: str, rssi: float):
             CONF_CYPRESS_HUMIDITY: 125.0 * (minor & 0xff00) / 65536 - 6,
         }
 
-        sensor_data = {
-            CONF_TYPE: DEVICE_TYPE,
-            CONF_PACKET: "no packet id",
-            CONF_FIRMWARE: DEVICE_TYPE,
-            CONF_DATA: True
-        } | tracker_data
+        sensor_data = dict(
+            {
+                CONF_TYPE: DEVICE_TYPE,
+                CONF_PACKET: "no packet id",
+                CONF_FIRMWARE: DEVICE_TYPE,
+                CONF_DATA: True
+            },
+            **tracker_data
+        )
     else:
         if self.report_unknown == DEVICE_TYPE:
             _LOGGER.info(

--- a/package/bleparser/tilt.py
+++ b/package/bleparser/tilt.py
@@ -45,14 +45,17 @@ def parse_tilt(self, data: str, source_mac: str, rssi: float):
             CONF_MEASURED_POWER: power,
         }
 
-        sensor_data = {
-            CONF_TYPE: device_type,
-            CONF_PACKET: "no packet id",
-            CONF_FIRMWARE: "Tilt",
-            CONF_DATA: True,
-            CONF_TEMPERATURE: (major - 32) * 5 / 9,
-            CONF_GRAVITY: minor / 1000,
-        } | tracker_data
+        sensor_data = dict(
+            {
+                CONF_TYPE: device_type,
+                CONF_PACKET: "no packet id",
+                CONF_FIRMWARE: "Tilt",
+                CONF_DATA: True,
+                CONF_TEMPERATURE: (major - 32) * 5 / 9,
+                CONF_GRAVITY: minor / 1000,
+            },
+            **tracker_data
+        )
     else:
         if self.report_unknown == "Tilt":
             _LOGGER.info(


### PR DESCRIPTION
The union operator ("|") for dictionaries was used in some places.
For dictionaries it is only supported for python version >= 3.9 (https://peps.python.org/pep-0584/).
In setup.cfg python >= 3.8 was defined (python_requires = >=3.8).
To preserve compatibility with 3.8 I changed the union operators for dicts.