### PR TITLE
Use properly captured data for the Almendo test

### DIFF
--- a/package/tests/test_almendo.py
+++ b/package/tests/test_almendo.py
@@ -6,7 +6,7 @@ class TestAlmendo:
     """Tests for the Almendo parser"""
     def test_almendo_blusensor_mini(self):
         """Test Almendo parser for bBluSensor mini."""
-        data_string = "043e26020103010eba64c4f5fc1a02010613ffe806010a0a08011800fb09e511a6030f0203020a093d"
+        data_string = "043e26020100000eba64c4f5fc1a02010613ffe806010a0a08011800be0a8b128208860505020a09d5"
         data = bytes(bytearray.fromhex(data_string))
         # pylint: disable=unused-variable
         ble_parser = BleParser()
@@ -17,9 +17,9 @@ class TestAlmendo:
         assert sensor_msg["mac"] == "FCF5C464BA0E"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"] == 25.55
-        assert sensor_msg["humidity"] == 45.81
-        assert sensor_msg["tvoc"] == 527
-        assert sensor_msg["aqi"] == 3
-        assert sensor_msg["co2"] == 934
-        assert sensor_msg["rssi"] == 61
+        assert sensor_msg["temperature"] == 27.5
+        assert sensor_msg["humidity"] == 47.47
+        assert sensor_msg["tvoc"] == 1414
+        assert sensor_msg["aqi"] == 5
+        assert sensor_msg["co2"] == 2178
+        assert sensor_msg["rssi"] == -43


### PR DESCRIPTION
The previous test data contained a positive RSSI; this data has negative RSSI.