### PR TITLE
govee: Fix H5072/H5075/H5101/H5102/H5177/H5178 temperature/humidity values

### DIFF
--- a/package/bleparser/govee.py
+++ b/package/bleparser/govee.py
@@ -11,12 +11,18 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def decode_temps(packet_value: int) -> float:
-    """Decode potential negative temperatures."""
+    """Decode temperature values (to one decimal place)"""
     # https://github.com/Thrilleratplay/GoveeWatcher/issues/2
     if packet_value & 0x800000:
-        return float((packet_value ^ 0x800000) / -10000)
-    return float(packet_value / 10000)
+        # Handle freezing temperatures
+        packet_value &= 0x7FFFFF
+        return float(int(packet_value / 1000) / -10)
+    return float(int(packet_value / 1000) / 10)
 
+def decode_humi(packet_value: int) -> float:
+    """Decode humidity values (to one decimal place)"""
+    packet_value &= 0x7FFFFF
+    return float((packet_value % 1000) / 10)
 
 def decode_temps_probes(packet_value: int) -> float:
     """Filter potential negative temperatures."""
@@ -41,7 +47,7 @@ def parse_govee(self, data, source_mac, rssi):
         packet_5072_5075 = data[5:8].hex()
         packet = int(packet_5072_5075, 16)
         temp = decode_temps(packet)
-        humi = float((packet % 1000) / 10)
+        humi = decode_humi(packet)
         batt = int(data[8])
         result.update({"temperature": temp, "humidity": humi, "battery": batt})
     elif msg_length == 10 and device_id == 0x0001:
@@ -49,7 +55,7 @@ def parse_govee(self, data, source_mac, rssi):
         packet_5101_5102 = data[6:9].hex()
         packet = int(packet_5101_5102, 16)
         temp = decode_temps(packet)
-        humi = float((packet % 1000) / 10)
+        humi = decode_humi(packet)
         batt = int(data[9])
         result.update({"temperature": temp, "humidity": humi, "battery": batt})
     elif msg_length == 11 and device_id == 0xEC88:
@@ -64,7 +70,7 @@ def parse_govee(self, data, source_mac, rssi):
         packet_5178 = data[7:10].hex()
         packet = int(packet_5178, 16)
         temp = decode_temps(packet)
-        humi = float((packet % 1000) / 10)
+        humi = decode_humi(packet)
         batt = int(data[10])
         sensor_id = data[6]
         result.update(

--- a/package/tests/test_govee_parser.py
+++ b/package/tests/test_govee_parser.py
@@ -53,7 +53,7 @@ class TestGovee:
         assert sensor_msg["mac"] == "E1121D61BBAA"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"] == 24.8577
+        assert sensor_msg["temperature"] == 24.8
         assert sensor_msg["humidity"] == 57.7
         assert sensor_msg["battery"] == 100
         assert sensor_msg["rssi"] == -86
@@ -71,8 +71,26 @@ class TestGovee:
         assert sensor_msg["mac"] == "A4C13861BBAA"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"] == 20.5149
+        assert sensor_msg["temperature"] == 20.5
         assert sensor_msg["humidity"] == 14.9
+        assert sensor_msg["battery"] == 100
+        assert sensor_msg["rssi"] == -86
+
+    def test_Govee_H5075_negative_temp(self):
+        """Test Govee H5075 parser."""
+        data_string = "043e2b02010000aabb6138c1a41f0d09475648353037355f43423942030388ec02010509ff88ec0081c2896400aa"
+        data = bytes(bytearray.fromhex(data_string))
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg["firmware"] == "Govee"
+        assert sensor_msg["type"] == "H5072/H5075"
+        assert sensor_msg["mac"] == "A4C13861BBAA"
+        assert sensor_msg["packet"] == "no packet id"
+        assert sensor_msg["data"]
+        assert sensor_msg["temperature"] == -11.5
+        assert sensor_msg["humidity"] == 33.7
         assert sensor_msg["battery"] == 100
         assert sensor_msg["rssi"] == -86
 
@@ -89,7 +107,7 @@ class TestGovee:
         assert sensor_msg["mac"] == "A4C138246C11"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"] == 7.7166
+        assert sensor_msg["temperature"] == 7.7
         assert sensor_msg["humidity"] == 16.6
         assert sensor_msg["battery"] == 100
         assert sensor_msg["rssi"] == -77
@@ -107,7 +125,7 @@ class TestGovee:
         assert sensor_msg["mac"] == "A4C138DFC545"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"] == 23.7583
+        assert sensor_msg["temperature"] == 23.7
         assert sensor_msg["humidity"] == 58.3
         assert sensor_msg["sensor id"] == 0
         assert sensor_msg["battery"] == 100
@@ -126,7 +144,7 @@ class TestGovee:
         assert sensor_msg["mac"] == "A4C138DFC546"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"] == 19.5719
+        assert sensor_msg["temperature"] == 19.5
         assert sensor_msg["humidity"] == 71.9
         assert sensor_msg["sensor id"] == 1
         assert sensor_msg["battery"] == 100


### PR DESCRIPTION
Fix the temperature and humidity decoding functions:
* Temperature is accurate only to one decimal place; remove duplicated humidity values in subsequent decimal places
* Humidity values are incorrect when temperature is below freezing (2's complement); mask upper bit before decoding

Govee tests updated accordingly and passing