### PR TITLE
Add support for multiple button devices

### DIFF
--- a/package/bleparser/bthome.py
+++ b/package/bleparser/bthome.py
@@ -220,6 +220,13 @@ def parse_payload(self, payload, sw_version):
             )
             continue
 
+        # Old Shelly buttons send 0xFE when held, rather than 0x80.
+        if (
+            MEAS_TYPES[meas["measurement type"]].meas_format == "button" and
+            meas["measurement data"] == b"\xFE"
+        ):
+            meas["measurement data"] = b'\x80'
+
         if meas["measurement type"] in dup_meas_types:
             # Add a postfix for advertisements with multiple measurements of the same type
             postfix_counter = postfix_dict.get(meas["measurement type"], 0) + 1
@@ -230,7 +237,7 @@ def parse_payload(self, payload, sw_version):
 
         meas_type = MEAS_TYPES[meas["measurement type"]]
         meas_unit = meas_type.unit_of_measurement
-        meas_format = meas_type.meas_format
+        meas_format = f"{meas_type.meas_format}{postfix}"
         meas_factor = meas_type.factor
         value: None | str | int | float
 

--- a/package/bleparser/bthome_const.py
+++ b/package/bleparser/bthome_const.py
@@ -205,6 +205,9 @@ MEAS_TYPES: dict[int, MeasTypes] = {
         meas_format="moisture",
         unit_of_measurement="%",
     ),
+    0x3A: MeasTypes(
+        meas_format="button",
+    ),
     0x3D: MeasTypes(
         meas_format="count",
         data_length=2,

--- a/package/tests/test_bthome_v2.py
+++ b/package/tests/test_bthome_v2.py
@@ -474,7 +474,7 @@ class TestBTHome:
         assert sensor_msg["rssi"] == -52
 
     def test_bthome_v2_double_temperature(self):
-        """Test BTHome parser for double temperature measurement, which isn't supported (yet)"""
+        """Test BTHome parser for double temperature measurement"""
         data_string = "043E1A02010000A5808FE648540E0201060A16D2FC40450101450301CC"
         data = bytes(bytearray.fromhex(data_string))
 
@@ -487,5 +487,27 @@ class TestBTHome:
         assert sensor_msg["mac"] == "5448E68F80A5"
         assert sensor_msg["packet"] == "no packet id"
         assert sensor_msg["data"]
-        assert sensor_msg["temperature"] == 25.9
+        assert sensor_msg["temperature_1"] == 25.7
+        assert sensor_msg["temperature_2"] == 25.9
         assert sensor_msg["rssi"] == -52
+
+    def test_bthome_v2_quadruple_button(self):
+        """Test BTHome parser for quadruple button"""
+        data_string = "043e2002010301ca2474b6c67c140201061016d2fc4400c201643a003a033a013a00bd"
+        data = bytes(bytearray.fromhex(data_string))
+
+        # pylint: disable=unused-variable
+        ble_parser = BleParser()
+        sensor_msg, tracker_msg = ble_parser.parse_raw_data(data)
+
+        assert sensor_msg["firmware"] == "BTHome V2"
+        assert sensor_msg["type"] == "BTHome"
+        assert sensor_msg["mac"] == "7CC6B67424CA"
+        assert sensor_msg["packet"] == 194
+        assert sensor_msg["battery"] == 100
+        assert sensor_msg["data"]
+        assert sensor_msg["button_1"] == 0
+        assert sensor_msg["button_2"] == 3
+        assert sensor_msg["button_3"] == 1
+        assert sensor_msg["button_4"] == 0
+        assert sensor_msg["rssi"] == -67


### PR DESCRIPTION
This adds support for event 0x3A, button, in the form of a regular sensor. The button used has four buttons, and thus this also adds support for multiple measurements, as described in the BTHome v2 format documentation ( https://bthome.io/format/ ):

> If you want to send multiple measurements of the same type, e.g. three temperatures, you can just add multiple measurements of the same type to the payload. A postfix will be added to the measurement name (e.g. temperature_2) in the order of which you define the measurements.

As a side effect, this now also happens to any supported multiple measurements sensors. The BTHome documentation is not consistent with how multiple measurements are handled in bthome-ble ( https://github.com/Bluetooth-Devices/bthome-ble/ ).

The button used sends 0xFE when held down, which is not consistent with the BTHome v2 specification. It is silently converted to 0x80, which is the proper code for held buttons.